### PR TITLE
文档中的Windows批处理示例指定代码页为UTF-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ JAR 文件)
 
 ```bat
 @echo off
+chcp 65001
 title PeerBanHelper
 :main
 java -Xmx256M -XX:+UseSerialGC -Dfile.encoding=UTF-8 -Dstdout.encoding=UTF-8 -Dstderr.encoding=UTF-8 -Dconsole.encoding=UTF-8 -Duser.language=en -Duser.region=US -jar PeerBanHelper.jar


### PR DESCRIPTION
避免出现中文乱码的情况