### PR TITLE
Use 2-stage Dockerfile to ensure image reproducible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,5 @@ LABEL MAINTAINER="https://github.com/PBH-BTN/PeerBanHelper"
 ENV TZ=UTC
 WORKDIR /app
 COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
-
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
 CMD ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,10 @@ FROM debian:stable-slim
 LABEL MAINTAINER="https://github.com/PBH-BTN/PeerBanHelper"
 
 ENV TZ=UTC
+ENV JAVA_HOME=/opt/java/openjdk
+ENV PATH "${JAVA_HOME}/bin:${PATH}"
 WORKDIR /app
 COPY --from=build target/PeerBanHelper.jar /app/PeerBanHelper.jar
+COPY --from=build /javaruntime $JAVA_HOME
 
 CMD ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM maven:3.9.6-eclipse-temurin-22 as build
 ADD ./pom.xml pom.xml
 ADD ./src src/
 ADD ./setup-webui.sh setup-webui.sh
-RUN apt-get update && apt-get install -y git && \
-    sh setup-webui.sh && mvn -B clean package --file pom.xml && \
+RUN sh setup-webui.sh && mvn -B clean package --file pom.xml && \
     RUN $JAVA_HOME/bin/jlink \
          --add-modules java.base \
          --strip-debug \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM maven:3.9.6-eclipse-temurin-22 as build
 
-ADD ./pom.xml pom.xml
-ADD ./src src/
-ADD ./setup-webui.sh setup-webui.sh
+ADD . /build
 RUN sh setup-webui.sh && mvn -B clean package --file pom.xml && \
-    RUN $JAVA_HOME/bin/jlink \
+    $JAVA_HOME/bin/jlink \
          --add-modules java.base \
          --strip-debug \
          --no-man-pages \
@@ -19,7 +17,7 @@ ENV TZ=UTC
 ENV JAVA_HOME=/opt/java/openjdk
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 WORKDIR /app
-COPY --from=build target/PeerBanHelper.jar /app/PeerBanHelper.jar
+COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
 COPY --from=build /javaruntime $JAVA_HOME
 
 CMD ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,10 @@ RUN sh setup-webui.sh && mvn -B clean package --file pom.xml
 
 FROM ubuntu/jre:17_edge
 LABEL MAINTAINER="https://github.com/PBH-BTN/PeerBanHelper"
-
+USER 0
 ENV TZ=UTC
 WORKDIR /app
+VOLUME /tmp
 COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
 ENTRYPOINT ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM maven:3.9.6-eclipse-temurin-22 as build
 
 ADD . /build
+WORKDIR /build
 RUN sh setup-webui.sh && mvn -B clean package --file pom.xml && \
     $JAVA_HOME/bin/jlink \
          --add-modules java.base \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ FROM eclipse-temurin:22 as build
 ADD ./pom.xml pom.xml
 ADD ./src src/
 ADD ./setup-webui.sh setup-webui.sh
-
-RUN sh setup-webui.sh && mvn -B clean package --file pom.xml && \
+RUN apt-get update && apt-get install -y maven git && \
+    sh setup-webui.sh && mvn -B clean package --file pom.xml && \
     RUN $JAVA_HOME/bin/jlink \
          --add-modules java.base \
          --strip-debug \

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,4 @@ ENV TZ=UTC
 WORKDIR /app
 COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
 ENV PATH "${JAVA_HOME}/bin:${PATH}"
-CMD ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]
+ENTRYPOINT ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,23 +2,13 @@ FROM maven:3.9.6-eclipse-temurin-22 as build
 
 ADD . /build
 WORKDIR /build
-RUN sh setup-webui.sh && mvn -B clean package --file pom.xml && \
-    $JAVA_HOME/bin/jlink \
-         --add-modules java.base \
-         --strip-debug \
-         --no-man-pages \
-         --no-header-files \
-         --compress=2 \
-         --output /javaruntime
+RUN sh setup-webui.sh && mvn -B clean package --file pom.xml
 
-FROM debian:stable-slim
+FROM ubuntu/jre:17_edge
 LABEL MAINTAINER="https://github.com/PBH-BTN/PeerBanHelper"
 
 ENV TZ=UTC
-ENV JAVA_HOME=/opt/java/openjdk
-ENV PATH "${JAVA_HOME}/bin:${PATH}"
 WORKDIR /app
 COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
-COPY --from=build /javaruntime $JAVA_HOME
 
 CMD ["java","-Xmx256M","-XX:+UseSerialGC","-jar","PeerBanHelper.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM eclipse-temurin:22 as build
+FROM maven:3.9.6-eclipse-temurin-22 as build
 
 ADD ./pom.xml pom.xml
 ADD ./src src/
 ADD ./setup-webui.sh setup-webui.sh
-RUN apt-get update && apt-get install -y maven git && \
+RUN apt-get update && apt-get install -y git && \
     sh setup-webui.sh && mvn -B clean package --file pom.xml && \
     RUN $JAVA_HOME/bin/jlink \
          --add-modules java.base \

--- a/setup-webui.sh
+++ b/setup-webui.sh
@@ -3,5 +3,5 @@ current_wd=$(pwd)
 cd "$(dirname $0)/src/main/resources"
 rm -rf static
 git clone --depth 1  --branch gh-pages "https://github.com/PBH-BTN/pbh-fe.git" static
-echo "WebUI Version: $(git rev-parse --short HEAD)"
+cd static && echo "WebUI Version: $(git rev-parse --short HEAD)"
 cd $current_wd


### PR DESCRIPTION
To ensure the image reproducible, the dockerfile shouldn't rely on any external binary, this PR build the .jar in the docker, and then pack it with a smaller jre, which size is only just a half of the current one.

![image](https://github.com/PBH-BTN/PeerBanHelper/assets/19235246/495a84fc-34f1-40f1-b875-f462d48acb15)

This image has been tested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated the Docker configuration to enhance the build process and optimize the runtime environment.
	- Improved the setup script for the WebUI to ensure operations are executed in the correct directory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->