### PR TITLE
使用guava中的Bloom过滤器以减少外部依赖

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,11 +327,6 @@
             <version>2.5</version>
         </dependency>
         <dependency>
-            <groupId>cn.hutool</groupId>
-            <artifactId>hutool-bloomFilter</artifactId>
-            <version>${hutool.version}</version>
-        </dependency>
-        <dependency>
             <groupId>io.javalin</groupId>
             <artifactId>javalin</artifactId>
             <version>6.1.3</version>

--- a/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
@@ -1,13 +1,12 @@
 package com.ghostchu.peerbanhelper.database;
 
-import cn.hutool.core.util.StrUtil;
 import com.ghostchu.peerbanhelper.text.Lang;
 import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
-import java.sql.*;
 import java.sql.Date;
+import java.sql.*;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -308,10 +307,10 @@ public class DatabaseHelper {
     public int countRuleSubLogs(String ruleId) throws SQLException {
         try (Connection connection = manager.getConnection()) {
             PreparedStatement ps;
-            boolean idNotEmpty = StrUtil.isNotEmpty(ruleId);
-            StringBuilder sql = StrUtil.builder().append("SELECT count(1) as count FROM rule_sub_logs ");
-            sql.append(idNotEmpty ? "WHERE rule_id = ? " : "");
-            ps = connection.prepareStatement(sql.toString());
+            boolean idNotEmpty = null != ruleId && !ruleId.isEmpty();
+            String sql = "SELECT count(1) as count FROM rule_sub_logs " +
+                    (idNotEmpty ? "WHERE rule_id = ? " : "");
+            ps = connection.prepareStatement(sql);
             if (idNotEmpty) {
                 ps.setString(1, ruleId);
             }
@@ -339,11 +338,11 @@ public class DatabaseHelper {
     public List<RuleSubLog> queryRuleSubLogs(String ruleId, int pageIndex, int pageSize) throws SQLException {
         try (Connection connection = manager.getConnection()) {
             PreparedStatement ps;
-            boolean idNotEmpty = StrUtil.isNotEmpty(ruleId);
-            StringBuilder sql = StrUtil.builder().append("SELECT * FROM rule_sub_logs ");
-            sql.append(idNotEmpty ? "WHERE rule_id = ? " : "");
-            sql.append("ORDER BY id DESC LIMIT ").append(pageIndex * pageSize).append(", ").append(pageSize);
-            ps = connection.prepareStatement(sql.toString());
+            boolean idNotEmpty = null != ruleId && !ruleId.isEmpty();
+            String sql = "SELECT * FROM rule_sub_logs " +
+                    (idNotEmpty ? "WHERE rule_id = ? " : "") +
+                    "ORDER BY id DESC LIMIT " + pageIndex * pageSize + ", " + pageSize;
+            ps = connection.prepareStatement(sql);
             if (idNotEmpty) {
                 ps.setString(1, ruleId);
             }


### PR DESCRIPTION
发现guava中已经有bloomfilter的实现，去掉hutool-bloomFilter的依赖

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed dependency on `hutool-bloomFilter`.
  - Replaced `FileUtil` operations with `Files` for file handling.
  - Switched from `BitSetBloomFilter` to `com.google.common.hash.BloomFilter` for improved hashing.

- **Bug Fixes**
  - Improved exception handling in various methods to ensure robust error management.

- **Performance Improvements**
  - Enhanced performance of SQL query building by simplifying string concatenation logic.
  - Optimized file handling and logging operations in rule updates.

- **Code Quality**
  - Reorganized and cleaned up import statements.
  - Refactored methods to use more efficient and modern approaches for string and file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->