### PR TITLE
v4.3.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
     <packaging>takari-jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>4.2.4</version>
+    <version>4.3.0</version>
     <packaging>takari-jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -485,5 +485,11 @@
             <artifactId>libby-standalone</artifactId> <!-- Replace bukkit if you're using another platform -->
             <version>2.0.2-SNAPSHOT</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.json/json -->
+        <dependency>
+            <groupId>org.json</groupId>
+            <artifactId>json</artifactId>
+            <version>20240303</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <properties>
         <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <mainClass>com.ghostchu.peerbanhelper.Main</mainClass>
+        <mainClass>com.ghostchu.peerbanhelper.MainJumpLoader</mainClass>
         <maven.build.timestamp.format>yyyyMMdd-HHmmss</maven.build.timestamp.format>
         <flatlafVersion>3.4.1</flatlafVersion>
         <hutool.version>5.8.27</hutool.version>

--- a/src/main/java/com/ghostchu/peerbanhelper/MainJumpLoader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/MainJumpLoader.java
@@ -1,0 +1,47 @@
+package com.ghostchu.peerbanhelper;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+public class MainJumpLoader {
+    public static void main(String[] args) {
+        // Do something before real Main class
+        if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+            setupCharsets();
+        }
+        Main.main(args);
+    }
+
+    private static void setupCharsets() {
+        try {
+            invokeCommand("cmd.exe /c chcp 65001", Collections.emptyMap());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static int invokeCommand(String command, Map<String, String> env) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        StringTokenizer st = new StringTokenizer(command);
+        String[] cmdarray = new String[st.countTokens()];
+        for (int i = 0; st.hasMoreTokens(); i++) {
+            cmdarray[i] = st.nextToken();
+        }
+        ProcessBuilder builder = new ProcessBuilder(cmdarray)
+                .inheritIO();
+        Map<String, String> liveEnv = builder.environment();
+        liveEnv.putAll(env);
+        Process p = builder.start();
+        Process process = p.onExit().get(10, TimeUnit.SECONDS);
+        if (process.isAlive()) {
+            process.destroy();
+            return -9999;
+        }
+        return process.exitValue();
+    }
+
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -7,7 +7,7 @@ import com.ghostchu.peerbanhelper.database.DatabaseManager;
 import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLastStatus;
 import com.ghostchu.peerbanhelper.downloader.impl.biglybt.BiglyBT;
-import com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission.Deluge;
+import com.ghostchu.peerbanhelper.downloader.impl.deluge.Deluge;
 import com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.QBittorrent;
 import com.ghostchu.peerbanhelper.downloader.impl.transmission.Transmission;
 import com.ghostchu.peerbanhelper.event.LivePeersUpdatedEvent;

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -576,8 +576,12 @@ public class PeerBanHelperServer {
         Map<Downloader, Map<Torrent, List<Peer>>> peers = new HashMap<>();
         try (var service = Executors.newVirtualThreadPerTaskExecutor()) {
             downloaders.forEach(downloader -> service.submit(() -> {
-                Map<Torrent, List<Peer>> p = collectPeers(downloader);
-                peers.put(downloader, p);
+                try {
+                    Map<Torrent, List<Peer>> p = collectPeers(downloader);
+                    peers.put(downloader, p);
+                } catch (Exception e) {
+                    log.warn(Lang.DOWNLOADER_UNHANDLED_EXCEPTION, e);
+                }
             }));
         }
         return peers;

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -7,6 +7,7 @@ import com.ghostchu.peerbanhelper.database.DatabaseManager;
 import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLastStatus;
 import com.ghostchu.peerbanhelper.downloader.impl.biglybt.BiglyBT;
+import com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission.Deluge;
 import com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.QBittorrent;
 import com.ghostchu.peerbanhelper.downloader.impl.transmission.Transmission;
 import com.ghostchu.peerbanhelper.event.LivePeersUpdatedEvent;
@@ -168,6 +169,7 @@ public class PeerBanHelperServer {
             case "transmission" ->
                     downloader = Transmission.loadFromConfig(client, pbhServerAddress, downloaderSection);
             case "biglybt" -> downloader = BiglyBT.loadFromConfig(client, downloaderSection);
+            case "deluge" -> downloader = Deluge.loadFromConfig(client, downloaderSection);
         }
         return downloader;
 
@@ -180,6 +182,7 @@ public class PeerBanHelperServer {
             case "transmission" ->
                     downloader = Transmission.loadFromConfig(client, pbhServerAddress, downloaderSection);
             case "biglybt" -> downloader = BiglyBT.loadFromConfig(client, downloaderSection);
+            case "deluge" -> downloader = Deluge.loadFromConfig(client, downloaderSection);
         }
         return downloader;
 
@@ -433,7 +436,7 @@ public class PeerBanHelperServer {
                             });
                         });
 
-                    needRelaunched.put(downloader, relaunch);
+                        needRelaunched.put(downloader, relaunch);
                     } catch (Exception e) {
                         log.error("Unable to complete peer ban task, report to PBH developer!!!");
                     }

--- a/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
@@ -26,6 +26,12 @@ public class MainConfigUpdateScript {
         }
     }
 
+    @UpdateScript(version = 9)
+    public void firewallIntegration() {
+        conf.set("firewall-integration", null);
+        conf.set("firewall-integration.windows-adv-firewall", true);
+    }
+
     @UpdateScript(version = 8)
     public void webToken() {
         conf.set("server.token", UUID.randomUUID().toString());

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -260,8 +260,8 @@ public class Deluge implements Downloader {
 //        static constexpr peer_source_flags_t lsd  = 3_bit;
 //        static constexpr peer_source_flags_t resume_data  = 4_bit;
 //        static constexpr peer_source_flags_t incoming  = 5_bit;
-        String binPeerFlag = Integer.toBinaryString(peerFlag);
-        String binSourceFlag = Integer.toBinaryString(sourceFlag);
+        String binPeerFlag = readBits(peerFlag, 21);
+        String binSourceFlag = readBits(sourceFlag, 6);
         char[] peerFlags = binPeerFlag.toCharArray();
         char[] sourceFlags = binSourceFlag.toCharArray();
         boolean interesting = c2b(peerFlags[0]);
@@ -359,6 +359,15 @@ public class Deluge implements Downloader {
 
     private boolean c2b(char c) {
         return c == '1';
+    }
+
+    private String readBits(int i, int bitLength) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(Integer.toBinaryString(i));
+        while (builder.length() < bitLength) {
+            builder.append("0");
+        }
+        return builder.toString();
     }
 
     @NoArgsConstructor

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -231,131 +231,78 @@ public class Deluge implements Downloader {
     public void close() {
 
     }
-
     private String parseFlag(int peerFlag, int sourceFlag) {
-//        static constexpr peer_flags_t interesting  = 0_bit;
-//        static constexpr peer_flags_t choked  = 1_bit;
-//        static constexpr peer_flags_t remote_interested  = 2_bit;
-//        static constexpr peer_flags_t remote_choked  = 3_bit;
-//        static constexpr peer_flags_t supports_extensions  = 4_bit;
-//        static constexpr peer_flags_t outgoing_connection  = 5_bit;
-//        static constexpr peer_flags_t local_connection  = 5_bit;
-//        static constexpr peer_flags_t handshake  = 6_bit;
-//        static constexpr peer_flags_t connecting  = 7_bit;
-//        static constexpr peer_flags_t on_parole  = 9_bit;
-//        static constexpr peer_flags_t seed  = 10_bit;
-//        static constexpr peer_flags_t optimistic_unchoke  = 11_bit;
-//        static constexpr peer_flags_t snubbed  = 12_bit;
-//        static constexpr peer_flags_t upload_only  = 13_bit;
-//        static constexpr peer_flags_t endgame_mode  = 14_bit;
-//        static constexpr peer_flags_t holepunched  = 15_bit;
-//        static constexpr peer_flags_t i2p_socket  = 16_bit;
-//        static constexpr peer_flags_t utp_socket  = 17_bit;
-//        static constexpr peer_flags_t ssl_socket  = 18_bit;
-//        static constexpr peer_flags_t rc4_encrypted  = 19_bit;
-//        static constexpr peer_flags_t plaintext_encrypted  = 20_bit;
-//        static constexpr peer_source_flags_t tracker  = 0_bit;
-//        static constexpr peer_source_flags_t dht  = 1_bit;
-//        static constexpr peer_source_flags_t pex  = 2_bit;
-//        static constexpr peer_source_flags_t lsd  = 3_bit;
-//        static constexpr peer_source_flags_t resume_data  = 4_bit;
-//        static constexpr peer_source_flags_t incoming  = 5_bit;
-        String binPeerFlag = readBits(peerFlag, 21);
-        String binSourceFlag = readBits(sourceFlag, 6);
-        char[] peerFlags = binPeerFlag.toCharArray();
-        char[] sourceFlags = binSourceFlag.toCharArray();
-        boolean interesting = c2b(peerFlags[0]);
-        boolean choked = c2b(peerFlags[1]);
-        boolean remoteInterested = c2b(peerFlags[2]);
-        boolean remoteChoked = c2b(peerFlags[3]);
-        boolean supportsExtensions = c2b(peerFlags[4]);
-        boolean outgoingConnection = c2b(peerFlags[5]);
-        boolean localConnection = c2b(peerFlags[6]);
-        boolean handshake = c2b(peerFlags[7]);
-        boolean connecting = c2b(peerFlags[8]);
-        boolean onParole = c2b(peerFlags[9]);
-        boolean seed = c2b(peerFlags[10]);
-        boolean optimisticUnchoke = c2b(peerFlags[11]);
-        boolean snubbed = c2b(peerFlags[12]);
-        boolean uploadOnly = c2b(peerFlags[13]);
-        boolean endGameMode = c2b(peerFlags[14]);
-        boolean holePunched = c2b(peerFlags[15]);
-        boolean i2pSocket = c2b(peerFlags[16]);
-        boolean utpSocket = c2b(peerFlags[17]);
-        boolean sslSocket = c2b(peerFlags[18]);
-        boolean rc4Encrypted = c2b(peerFlags[19]);
-        boolean plainTextEncrypted = c2b(peerFlags[20]);
-        boolean tracker = c2b(sourceFlags[0]);
-        boolean dht = c2b(sourceFlags[1]);
-        boolean pex = c2b(sourceFlags[2]);
-        boolean lsd = c2b(sourceFlags[3]);
-        boolean resumeData = c2b(sourceFlags[4]);
-        boolean incoming = c2b(sourceFlags[5]);
+        boolean interesting = (peerFlag & (1 << 0)) != 0;
+        boolean choked = (peerFlag & (1 << 1)) != 0;
+        boolean remoteInterested = (peerFlag & (1 << 2)) != 0;
+        boolean remoteChoked = (peerFlag & (1 << 3)) != 0;
+        boolean supportsExtensions = (peerFlag & (1 << 4)) != 0;
+        boolean outgoingConnection = (peerFlag & (1 << 5)) != 0;
+        boolean localConnection = (peerFlag & (1 << 6)) != 0;
+        boolean handshake = (peerFlag & (1 << 7)) != 0;
+        boolean connecting = (peerFlag & (1 << 8)) != 0;
+        boolean onParole = (peerFlag & (1 << 9)) != 0;
+        boolean seed = (peerFlag & (1 << 10)) != 0;
+        boolean optimisticUnchoke = (peerFlag & (1 << 11)) != 0;
+        boolean snubbed = (peerFlag & (1 << 12)) != 0;
+        boolean uploadOnly = (peerFlag & (1 << 13)) != 0;
+        boolean endGameMode = (peerFlag & (1 << 14)) != 0;
+        boolean holePunched = (peerFlag & (1 << 15)) != 0;
+        boolean i2pSocket = (peerFlag & (1 << 16)) != 0;
+        boolean utpSocket = (peerFlag & (1 << 17)) != 0;
+        boolean sslSocket = (peerFlag & (1 << 18)) != 0;
+        boolean rc4Encrypted = (peerFlag & (1 << 19)) != 0;
+        boolean plainTextEncrypted = (peerFlag & (1 << 20)) != 0;
+
+        boolean tracker = (sourceFlag & (1 << 0)) != 0;
+        boolean dht = (sourceFlag & (1 << 1)) != 0;
+        boolean pex = (sourceFlag & (1 << 2)) != 0;
+        boolean lsd = (sourceFlag & (1 << 3)) != 0;
+        boolean resumeData = (sourceFlag & (1 << 4)) != 0;
+        boolean incoming = (sourceFlag & (1 << 5)) != 0;
+
         StringJoiner joiner = new StringJoiner(" ");
 
         if (interesting) {
             if (remoteChoked) {
-                // d = Your client wants to download, but peer doesn't want to send (interested and choked)
                 joiner.add("d");
             } else {
-                // D = Currently downloading (interested and not choked)
                 joiner.add("D");
             }
         }
         if (remoteInterested) {
             if (choked) {
-                // u = Peer wants your client to upload, but your client doesn't want to (interested and choked)
                 joiner.add("u");
             } else {
-                // U = Currently uploading (interested and not choked)
                 joiner.add("U");
             }
         }
-        // K = Peer is unchoking your client, but your client is not interested
         if (!remoteChoked && !interesting)
             joiner.add("K");
-
-        // ? = Your client unchoked the peer but the peer is not interested
         if (!choked && !remoteInterested)
             joiner.add("?");
-
-        // O = Optimistic unchoke
         if (optimisticUnchoke)
             joiner.add("O");
-
-        // S = Peer is snubbed
         if (snubbed)
             joiner.add("S");
-
-        // I = Peer is an incoming connection
         if (!localConnection)
             joiner.add("I");
-
-        // H = Peer was obtained through DHT
         if (dht)
             joiner.add("H");
-
-        // X = Peer was included in peerlists obtained through Peer Exchange (PEX)
         if (pex)
             joiner.add("X");
-
-        // L = Peer is local
         if (lsd)
             joiner.add("L");
-
-        // E = Peer is using Protocol Encryption (all traffic)
         if (rc4Encrypted)
             joiner.add("E");
-
-        // e = Peer is using Protocol Encryption (handshake)
         if (plainTextEncrypted)
             joiner.add("e");
-
-        // P = Peer is using uTorrent uTP
         if (utpSocket)
             joiner.add("P");
+
         return joiner.toString();
     }
+
 
     private boolean c2b(char c) {
         return c == '1';

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -1,4 +1,4 @@
-package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+package com.ghostchu.peerbanhelper.downloader.impl.deluge;
 
 import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderBasicAuth;

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/DelugePeer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/DelugePeer.java
@@ -1,4 +1,4 @@
-package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+package com.ghostchu.peerbanhelper.downloader.impl.deluge;
 
 import com.ghostchu.peerbanhelper.peer.Peer;
 import com.ghostchu.peerbanhelper.wrapper.PeerAddress;

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/DelugeTorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/DelugeTorrent.java
@@ -1,4 +1,4 @@
-package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+package com.ghostchu.peerbanhelper.downloader.impl.deluge;
 
 import com.ghostchu.peerbanhelper.peer.Peer;
 import com.ghostchu.peerbanhelper.torrent.Torrent;

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/Deluge.java
@@ -1,0 +1,277 @@
+package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+
+import com.ghostchu.peerbanhelper.downloader.Downloader;
+import com.ghostchu.peerbanhelper.downloader.DownloaderBasicAuth;
+import com.ghostchu.peerbanhelper.downloader.DownloaderLastStatus;
+import com.ghostchu.peerbanhelper.downloader.WebViewScriptCallback;
+import com.ghostchu.peerbanhelper.peer.Peer;
+import com.ghostchu.peerbanhelper.text.Lang;
+import com.ghostchu.peerbanhelper.torrent.Torrent;
+import com.ghostchu.peerbanhelper.util.JsonUtil;
+import com.ghostchu.peerbanhelper.wrapper.BanMetadata;
+import com.ghostchu.peerbanhelper.wrapper.PeerAddress;
+import com.ghostchu.peerbanhelper.wrapper.TorrentWrapper;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonObject;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
+import org.bspfsystems.yamlconfiguration.configuration.ConfigurationSection;
+import org.bspfsystems.yamlconfiguration.file.YamlConfiguration;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import raccoonfink.deluge.DelugeException;
+import raccoonfink.deluge.DelugeServer;
+import raccoonfink.deluge.responses.DelugeListMethodsResponse;
+import raccoonfink.deluge.responses.PBHActiveTorrentsResponse;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+
+public class Deluge implements Downloader {
+    private static final Logger log = org.slf4j.LoggerFactory.getLogger(Deluge.class);
+    private static final List<String> MUST_HAVE_METHODS = ImmutableList.of(
+            "peerbanhelperadapter.replace_blocklist",
+            "peerbanhelperadapter.unban_ips",
+            "peerbanhelperadapter.get_active_torrents_info",
+            "peerbanhelperadapter.ban_ips"
+    );
+    private final String name;
+    private final DelugeServer client;
+    private final Config config;
+    private DownloaderLastStatus lastStatus = DownloaderLastStatus.UNKNOWN;
+    private String statusMessage;
+
+    public Deluge(String name, Config config) {
+        this.name = name;
+        this.config = config;
+        this.client = new DelugeServer(config.getEndpoint() + config.getRpcUrl(), config.getPassword(), config.isVerifySsl(), HttpClient.Version.valueOf(config.getHttpVersion()), null, null);
+    }
+
+    public static Deluge loadFromConfig(String name, ConfigurationSection section) {
+        Config config = Config.readFromYaml(section);
+        return new Deluge(name, config);
+    }
+
+    public static Deluge loadFromConfig(String name, JsonObject section) {
+        Config config = JsonUtil.getGson().fromJson(section.toString(), Config.class);
+        return new Deluge(name, config);
+    }
+
+    private static String toStringHex(String s) {
+        byte[] baKeyword = new byte[s.length() / 2];
+        for (int i = 0; i < baKeyword.length; i++) {
+            baKeyword[i] = (byte) (0xff & Integer.parseInt(s.substring(i * 2, i * 2 + 2), 16));
+        }
+        return new String(baKeyword, StandardCharsets.ISO_8859_1);
+    }
+
+    @Override
+    public JsonObject saveDownloaderJson() {
+        return JsonUtil.getGson().toJsonTree(config).getAsJsonObject();
+    }
+
+    @Override
+    public YamlConfiguration saveDownloader() {
+        return config.saveToYaml();
+    }
+
+    @Override
+    public String getEndpoint() {
+        return config.getEndpoint();
+    }
+
+    @Override
+    public String getWebUIEndpoint() {
+        return config.getEndpoint();
+    }
+
+    @Override
+    public @Nullable DownloaderBasicAuth getDownloaderBasicAuth() {
+        return null;
+    }
+
+    @Override
+    public @Nullable WebViewScriptCallback getWebViewJavaScript() {
+        return null;
+    }
+
+    @Override
+    public boolean isSupportWebview() {
+        return true;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getType() {
+        return "Deluge";
+    }
+
+    @Override
+    public boolean login() {
+        try {
+            if (!this.client.login().isLoggedIn()) {
+                return false;
+            }
+            DelugeListMethodsResponse listMethodsResponse = this.client.listMethods();
+            if (!new HashSet<>(listMethodsResponse.getDelugeSupportedMethods()).containsAll(MUST_HAVE_METHODS)) {
+                log.warn(Lang.DOWNLOADER_DELUGE_PLUGIN_NOT_INSTALLED, getName());
+                return false;
+            }
+        } catch (DelugeException e) {
+            throw new RuntimeException(e);
+        }
+        return true;
+    }
+
+    @Override
+    public List<Torrent> getTorrents() {
+        List<Torrent> torrents = new ArrayList<>();
+        try {
+            for (PBHActiveTorrentsResponse.ActiveTorrentsResponseDTO activeTorrent : this.client.getActiveTorrents().getActiveTorrents()) {
+                List<Peer> peers = new ArrayList<>();
+                for (PBHActiveTorrentsResponse.ActiveTorrentsResponseDTO.PeersDTO peer : activeTorrent.getPeers()) {
+                    DelugePeer delugePeer = new DelugePeer(
+                            new PeerAddress(peer.getIp(), peer.getPort()),
+                            toStringHex(peer.getPeerId()),
+                            peer.getClientName(),
+                            peer.getTotalDownload(),
+                            peer.getPayloadDownSpeed(),
+                            peer.getTotalUpload(),
+                            peer.getPayloadUpSpeed(),
+                            peer.getProgress() / 100.0d,
+                            null
+                    );
+                    peers.add(delugePeer);
+                }
+                Torrent torrent = new DelugeTorrent(
+                        activeTorrent.getId(),
+                        activeTorrent.getName(),
+                        activeTorrent.getInfoHash(),
+                        activeTorrent.getProgress() / 100.0d,
+                        activeTorrent.getSize(),
+                        activeTorrent.getUploadPayloadRate(),
+                        activeTorrent.getDownloadPayloadRate(),
+                        peers
+                );
+                torrents.add(torrent);
+            }
+        } catch (DelugeException e) {
+            log.warn(Lang.DOWNLOADER_DELUGE_API_ERROR, e);
+        }
+        return torrents;
+    }
+
+    @Override
+    public List<Peer> getPeers(Torrent torrent) {
+        if (!(torrent instanceof DelugeTorrent delugeTorrent)) {
+            throw new IllegalStateException("The torrent object not a instance of DelugeTorrent");
+        }
+        return delugeTorrent.getPeers();
+    }
+
+    @SneakyThrows
+    @Override
+    public void setBanList(Collection<PeerAddress> fullList, @Nullable Collection<BanMetadata> added, @Nullable Collection<BanMetadata> removed) {
+        if (removed != null && removed.isEmpty() && added != null && config.isIncrementBan()) {
+            setBanListIncrement(added);
+        } else {
+            setBanListFull(fullList);
+        }
+    }
+
+    private void setBanListFull(Collection<PeerAddress> fullList) {
+        try {
+            this.client.replaceBannedPeers(fullList.stream().map(PeerAddress::getIp).toList());
+        } catch (DelugeException e) {
+            log.warn(Lang.DOWNLOADER_DELUGE_API_ERROR, e);
+        }
+    }
+
+    private void setBanListIncrement(Collection<BanMetadata> added) {
+        try {
+            this.client.banPeers(added.stream().map(bm -> bm.getPeer().getAddress().getIp()).toList());
+        } catch (DelugeException e) {
+            log.warn(Lang.DOWNLOADER_DELUGE_API_ERROR, e);
+        }
+    }
+
+    @Override
+    public void relaunchTorrentIfNeeded(Collection<Torrent> torrents) {
+
+    }
+
+    @Override
+    public void relaunchTorrentIfNeededByTorrentWrapper(Collection<TorrentWrapper> torrents) {
+
+    }
+
+    @Override
+    public DownloaderLastStatus getLastStatus() {
+        return lastStatus;
+    }
+
+    @Override
+    public void setLastStatus(DownloaderLastStatus lastStatus, String statusMessage) {
+        this.lastStatus = lastStatus;
+        this.statusMessage = statusMessage;
+    }
+
+    @Override
+    public String getLastStatusMessage() {
+        return statusMessage;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @NoArgsConstructor
+    @Data
+    public static class Config {
+
+        private String type;
+        private String endpoint;
+        private String password;
+        private String httpVersion;
+        private boolean verifySsl;
+        private String rpcUrl;
+        private boolean incrementBan;
+
+        public static Config readFromYaml(ConfigurationSection section) {
+            Config config = new Config();
+            config.setType("deluge");
+            config.setEndpoint(section.getString("endpoint"));
+            if (config.getEndpoint().endsWith("/")) { // 浏览器复制党 workaround 一下， 避免连不上的情况
+                config.setEndpoint(config.getEndpoint().substring(0, config.getEndpoint().length() - 1));
+            }
+            config.setPassword(section.getString("password"));
+            config.setRpcUrl(section.getString("rpc-url", "/json"));
+            config.setHttpVersion(section.getString("http-version", "HTTP_1_1"));
+            config.setVerifySsl(section.getBoolean("verify-ssl", true));
+            config.setIncrementBan(section.getBoolean("increment-ban"));
+            return config;
+        }
+
+        public YamlConfiguration saveToYaml() {
+            YamlConfiguration section = new YamlConfiguration();
+            section.set("type", "deluge");
+            section.set("endpoint", endpoint);
+            section.set("password", password);
+            section.set("rpc-url", rpcUrl);
+            section.set("http-version", httpVersion);
+            section.set("increment-ban", incrementBan);
+            section.set("verify-ssl", verifySsl);
+            return section;
+        }
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/DelugePeer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/DelugePeer.java
@@ -1,0 +1,20 @@
+package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+
+import com.ghostchu.peerbanhelper.peer.Peer;
+import com.ghostchu.peerbanhelper.wrapper.PeerAddress;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class DelugePeer implements Peer {
+    private PeerAddress peerAddress;
+    private String peerId;
+    private String clientName;
+    private long downloaded;
+    private long downloadSpeed;
+    private long uploaded;
+    private long uploadSpeed;
+    private double progress;
+    private String flags;
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/DelugeTorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/transmission/DelugeTorrent.java
@@ -1,0 +1,21 @@
+package com.ghostchu.peerbanhelper.downloader.impl.deluge.transmission;
+
+import com.ghostchu.peerbanhelper.peer.Peer;
+import com.ghostchu.peerbanhelper.torrent.Torrent;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@AllArgsConstructor
+public class DelugeTorrent implements Torrent {
+    private String id;
+    private String name;
+    private String hash;
+    private double progress;
+    private long size;
+    private long rtUploadSpeed;
+    private long rtDownloadSpeed;
+    private List<Peer> peers;
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/Transmission.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/Transmission.java
@@ -235,7 +235,7 @@ public class Transmission implements Downloader {
             }
             config.setUsername(section.getString("username"));
             config.setPassword(section.getString("password"));
-            config.setRpcUrl(section.getString("rpc-url", "transmission/rpc"));
+            config.setRpcUrl(section.getString("rpc-url", "/transmission/rpc"));
             config.setHttpVersion(section.getString("http-version", "HTTP_1_1"));
             config.setVerifySsl(section.getBoolean("verify-ssl", true));
             return config;

--- a/src/main/java/com/ghostchu/peerbanhelper/firewall/Firewall.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/firewall/Firewall.java
@@ -1,0 +1,19 @@
+package com.ghostchu.peerbanhelper.firewall;
+
+import inet.ipaddr.IPAddress;
+
+public interface Firewall {
+    String getName();
+
+    boolean isApplicable();
+
+    boolean ban(IPAddress address) throws Exception;
+
+    boolean unban(IPAddress address) throws Exception;
+
+    boolean reset() throws Exception;
+
+    boolean load() throws Exception;
+
+    boolean unload() throws Exception;
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/firewall/FirewallManager.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/firewall/FirewallManager.java
@@ -1,0 +1,25 @@
+package com.ghostchu.peerbanhelper.firewall;
+
+import com.ghostchu.peerbanhelper.PeerBanHelperServer;
+import com.ghostchu.peerbanhelper.firewall.impl.LocalWindowsAdvFirewall;
+import org.bspfsystems.yamlconfiguration.configuration.ConfigurationSection;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class FirewallManager {
+    private final PeerBanHelperServer server;
+    private Set<Firewall> enabledFirewalls = new HashSet<>();
+
+    public FirewallManager(PeerBanHelperServer server) {
+        this.server = server;
+    }
+
+    private void reloadConfig() {
+        ConfigurationSection section = server.getMainConfig().getConfigurationSection("firewall-integration");
+        if (section == null) throw new IllegalArgumentException("The firewall-integration section cannot be null");
+        if (section.getBoolean("windows-adv-firewall")) {
+            enabledFirewalls.add(new LocalWindowsAdvFirewall(server));
+        }
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/firewall/impl/CommandBasedImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/firewall/impl/CommandBasedImpl.java
@@ -1,0 +1,35 @@
+package com.ghostchu.peerbanhelper.firewall.impl;
+
+import com.ghostchu.peerbanhelper.text.Lang;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.StringTokenizer;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+@Slf4j
+public class CommandBasedImpl {
+
+    public int invokeCommand(String command, Map<String, String> env) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        StringTokenizer st = new StringTokenizer(command);
+        String[] cmdarray = new String[st.countTokens()];
+        for (int i = 0; st.hasMoreTokens(); i++) {
+            cmdarray[i] = st.nextToken();
+        }
+        ProcessBuilder builder = new ProcessBuilder(cmdarray)
+                .inheritIO();
+        Map<String, String> liveEnv = builder.environment();
+        liveEnv.putAll(env);
+        Process p = builder.start();
+        Process process = p.onExit().get(10, TimeUnit.SECONDS);
+        if (process.isAlive()) {
+            process.destroy();
+            log.warn(Lang.COMMAND_EXECUTOR_FAILED_TIMEOUT, command);
+            return -9999;
+        }
+        return process.exitValue();
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/firewall/impl/LocalWindowsAdvFirewall.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/firewall/impl/LocalWindowsAdvFirewall.java
@@ -1,0 +1,109 @@
+package com.ghostchu.peerbanhelper.firewall.impl;
+
+import com.ghostchu.peerbanhelper.PeerBanHelperServer;
+import com.ghostchu.peerbanhelper.firewall.Firewall;
+import inet.ipaddr.IPAddress;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.StringJoiner;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+public class LocalWindowsAdvFirewall extends CommandBasedImpl implements Firewall {
+    private static final String PBH_GUID = new UUID(7355608L, 1145141919810L).toString();
+    private static final String CMD_TEST_START = """
+            New-NetFirewallRule -Id "peerbanhelper-test" -DisplayName "PeerBanHelperTest"
+            """;
+    private static final String CMD_TEST_END = """
+            New-NetFirewallRule -Id "peerbanhelper-test" -DisplayName "PeerBanHelperTest"
+            """;
+    private static final String CMD_REMOVE_FIREWALL_RULE = """
+            Remove-NetFirewallDynamicKeywordAddress -Id {%s}
+            """;
+    private static final String CMD_NEW_INBOUND_FIREWALL_RULE = """
+            New-NetFirewallRule -Id "peerbanhelper-inbound" -DisplayName "PeerBanHelper AdvFirewall Filter (Inbound)" -Direction Inbound -Action Block -RemoteDynamicKeywordAddresses "{%s}"
+            """;
+    private static final String CMD_REMOVE_INBOUND_FIREWALL_RULE = """
+            Remove-NetFirewallRule -Id "peerbanhelper-inbound"
+            """;
+    private static final String CMD_NEW_OUTBOUND_FIREWALL_RULE = """
+            New-NetFirewallRule Id "peerbanhelper-outbound" -DisplayName “PeerBanHelper AdvFirewall Filter (Outbound)” -Direction Outbound -Action Block -RemoteDynamicKeywordAddresses "{%s}"
+            """;
+    private static final String CMD_REMOVE_OUTBOUND_FIREWALL_RULE = """
+            Remove-NetFirewallRule -Id "peerbanhelper-outbound"
+            """;
+    private static final String CMD_CREATE_DYNAMIC_FIREWALL_KEYWORD = """
+            New-NetFirewallDynamicKeywordAddress -Id "{%s}" -Keyword "PBH-BanList" -Addresses "%s"
+            """;
+    private static final String CMD_DELETE_DYNAMIC_FIREWALL_KEYWORD = """
+            Remove-NetFirewallDynamicKeywordAddress -Id "{%s}"
+            """;
+    private final PeerBanHelperServer server;
+
+
+    public LocalWindowsAdvFirewall(PeerBanHelperServer server) {
+        this.server = server;
+    }
+
+    @Override
+    public String getName() {
+        return "Windows AdvFirewall (DynamicKeywordAddress)";
+    }
+
+    @Override
+    public boolean isApplicable() {
+        try {
+            invokeCommand(CMD_TEST_START, Collections.emptyMap());
+            invokeCommand(CMD_TEST_END, Collections.emptyMap());
+        } catch (IOException | ExecutionException | InterruptedException | TimeoutException e) {
+            throw new RuntimeException(e);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean ban(IPAddress address) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        invokeCommand(String.format(CMD_DELETE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID), Collections.emptyMap());
+        invokeCommand(String.format(CMD_CREATE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID, getAllAddress()), Collections.emptyMap());
+        return true;
+    }
+
+    @Override
+    public boolean unban(IPAddress address) throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        invokeCommand(String.format(CMD_DELETE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID), Collections.emptyMap());
+        invokeCommand(String.format(CMD_CREATE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID, getAllAddress()), Collections.emptyMap());
+        return true;
+    }
+
+    @Override
+    public boolean reset() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        invokeCommand(String.format(CMD_DELETE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID), Collections.emptyMap());
+        invokeCommand(CMD_REMOVE_INBOUND_FIREWALL_RULE, Collections.emptyMap());
+        invokeCommand(CMD_REMOVE_OUTBOUND_FIREWALL_RULE, Collections.emptyMap());
+        invokeCommand(String.format(CMD_NEW_INBOUND_FIREWALL_RULE, PBH_GUID), Collections.emptyMap());
+        invokeCommand(String.format(CMD_NEW_OUTBOUND_FIREWALL_RULE, PBH_GUID), Collections.emptyMap());
+        invokeCommand(String.format(CMD_CREATE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID, getAllAddress()), Collections.emptyMap());
+        return true;
+    }
+
+    @Override
+    public boolean load() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        return reset();
+    }
+
+    @Override
+    public boolean unload() throws IOException, ExecutionException, InterruptedException, TimeoutException {
+        invokeCommand(String.format(CMD_DELETE_DYNAMIC_FIREWALL_KEYWORD, PBH_GUID), Collections.emptyMap());
+        invokeCommand(CMD_REMOVE_OUTBOUND_FIREWALL_RULE, Collections.emptyMap());
+        invokeCommand(CMD_REMOVE_INBOUND_FIREWALL_RULE, Collections.emptyMap());
+        return true;
+    }
+
+    private String getAllAddress() {
+        StringJoiner joiner = new StringJoiner(",");
+        server.getBannedPeers().keySet().forEach(pa -> joiner.add(pa.getAddress().toString()));
+        return joiner.toString();
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHDownloaderController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHDownloaderController.java
@@ -126,9 +126,14 @@ public class PBHDownloaderController extends AbstractFeatureModule {
             ctx.json(Map.of("message", Lang.DOWNLOADER_API_ADD_FAILURE));
             return;
         }
-        boolean testResult = downloader.login();
-        ctx.status(HttpStatus.OK);
-        ctx.json(Map.of("message", Lang.DOWNLOADER_API_TEST_OK, "valid", testResult));
+        try {
+            boolean testResult = downloader.login();
+            ctx.status(HttpStatus.OK);
+            ctx.json(Map.of("message", Lang.DOWNLOADER_API_TEST_OK, "valid", testResult));
+        } catch (Exception e) {
+            ctx.status(HttpStatus.INTERNAL_SERVER_ERROR);
+            ctx.json(Map.of("message", e.getMessage(), "valid", false));
+        }
     }
 
     private void handleDownloaderDelete(Context ctx, String downloaderName) {

--- a/src/main/java/com/ghostchu/peerbanhelper/text/Lang.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/text/Lang.java
@@ -272,8 +272,7 @@ public class Lang {
     public static final String COMMAND_EXECUTOR = "[CommandExecutor] 命令执行器正在执行系统终端命令：{}";
     public static final String COMMAND_EXECUTOR_FAILED = "[CommandExecutor] 系统终端命令执行失败：{}";
     public static final String COMMAND_EXECUTOR_FAILED_TIMEOUT = "[CommandExecutor] 系统终端命令执行超时：{}";
-
     public static final String DOWNLOADER_DELUGE_PLUGIN_NOT_INSTALLED = "无法登录到下载器 {}，此 Deluge 下载器必须正确加载 PeerBanHelper Deluge Adapter 扩展插件：https://github.com/PBH-BTN/PBH-Adapter-Deluge";
     public static final String DOWNLOADER_DELUGE_API_ERROR = "执行 Deluge RPC 调用失败，操作被忽略";
-
+    public static final String DOWNLOADER_UNHANDLED_EXCEPTION = "发生了一个未处理的异常，请反馈给 PeerBanHelper 开发者，此错误已被跳过……";
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/text/Lang.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/text/Lang.java
@@ -269,4 +269,11 @@ public class Lang {
     public static final String DOWNLOADER_BIGLYBT_INCREAMENT_BAN_FAILED = "[错误] 向下载器请求增量封禁对等体时出现错误，请尝试在配置文件中关闭增量封禁(increment-ban)配置项";
     public static final String DOWNLOADER_BIGLYBT_FAILED_SAVE_BANLIST = "无法保存 {} ({}) 的 Banlist！{} - {}\n{}";
     public static final String ALERT_INCORRECT_PROXY_SETTING = "警告！通过 HTTP_PROXY 环境变量无法为 Java 应用程序设置代理服务器！您的代理设置可能并不会生效。";
+    public static final String COMMAND_EXECUTOR = "[CommandExecutor] 命令执行器正在执行系统终端命令：{}";
+    public static final String COMMAND_EXECUTOR_FAILED = "[CommandExecutor] 系统终端命令执行失败：{}";
+    public static final String COMMAND_EXECUTOR_FAILED_TIMEOUT = "[CommandExecutor] 系统终端命令执行超时：{}";
+
+    public static final String DOWNLOADER_DELUGE_PLUGIN_NOT_INSTALLED = "无法登录到下载器 {}，此 Deluge 下载器必须正确加载 PeerBanHelper Deluge Adapter 扩展插件：https://github.com/PBH-BTN/PBH-Adapter-Deluge";
+    public static final String DOWNLOADER_DELUGE_API_ERROR = "执行 Deluge RPC 调用失败，操作被忽略";
+
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/time/RestrictedExecutor.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/time/RestrictedExecutor.java
@@ -18,6 +18,7 @@ public class RestrictedExecutor {
             return new RestrictedExecResult<>(true, null);
         } catch (InterruptedException e) {
             log.warn("Thread Interrupted", e);
+            Thread.currentThread().interrupt();
             return new RestrictedExecResult<>(false, null);
         } catch (ExecutionException e) {
             throw new RuntimeException(e);

--- a/src/main/java/raccoonfink/deluge/DelugeEvent.java
+++ b/src/main/java/raccoonfink/deluge/DelugeEvent.java
@@ -1,0 +1,15 @@
+package raccoonfink.deluge;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+public class DelugeEvent {
+
+    public DelugeEvent(final JSONArray data) {
+    }
+
+    public JSONObject toJSON() {
+        return new JSONObject();
+    }
+
+}

--- a/src/main/java/raccoonfink/deluge/DelugeException.java
+++ b/src/main/java/raccoonfink/deluge/DelugeException.java
@@ -1,0 +1,21 @@
+package raccoonfink.deluge;
+
+public class DelugeException extends Exception {
+    private static final long serialVersionUID = 1L;
+
+    public DelugeException() {
+    }
+
+    public DelugeException(final String message) {
+        super(message);
+    }
+
+    public DelugeException(final Throwable cause) {
+        super(cause);
+    }
+
+    public DelugeException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/raccoonfink/deluge/DelugeRequest.java
+++ b/src/main/java/raccoonfink/deluge/DelugeRequest.java
@@ -1,0 +1,27 @@
+package raccoonfink.deluge;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class DelugeRequest {
+    private final String m_method;
+    private final List<Object> m_params;
+
+    public DelugeRequest(final String method, final Object... params) {
+        m_method = method;
+        m_params = Arrays.asList(params);
+    }
+
+    public String toPostData(final int id) throws JSONException {
+        assert (id >= 0);
+        final JSONObject json = new JSONObject();
+        json.put("id", id);
+        json.put("method", m_method);
+        json.put("params", new JSONArray(m_params));
+        return json.toString();
+    }
+}

--- a/src/main/java/raccoonfink/deluge/DelugeServer.java
+++ b/src/main/java/raccoonfink/deluge/DelugeServer.java
@@ -94,6 +94,9 @@ public class DelugeServer {
                                 java.net.http.HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
             }
             connectionResponseCode = resp.statusCode();
+            if (connectionResponseCode != 200) {
+                throw new DelugeException(resp.statusCode() + " - " + resp.body());
+            }
             jsonResponse = new JSONObject(resp.body());
 //				List<String> setCookie = resp.headers().allValues("Set-Cookie");
 //				if(!setCookie.isEmpty()){

--- a/src/main/java/raccoonfink/deluge/DelugeServer.java
+++ b/src/main/java/raccoonfink/deluge/DelugeServer.java
@@ -1,0 +1,302 @@
+package raccoonfink.deluge;
+
+import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.util.HTTPUtil;
+import com.github.mizosoft.methanol.Methanol;
+import com.github.mizosoft.methanol.MutableRequest;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import raccoonfink.deluge.responses.*;
+
+import java.io.IOException;
+import java.net.*;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+
+public class DelugeServer {
+    private static final Logger log = LoggerFactory.getLogger(DelugeServer.class);
+    private final String m_url;
+    private final String m_password;
+    private final HttpClient httpClient;
+
+    private final CookieManager m_cookieManager = new CookieManager();
+    private int m_counter = 0;
+
+    public DelugeServer(final String url, final String password, boolean verifySSL, HttpClient.Version httpVersion, String baUser, String baPassword) {
+        m_url = url;
+        m_password = password;
+        m_cookieManager.setCookiePolicy(CookiePolicy.ACCEPT_ALL);
+
+        HttpURLConnection.setFollowRedirects(true);
+
+        HttpClient.Builder builder = Methanol
+                .newBuilder()
+                .version(httpVersion)
+                .followRedirects(HttpClient.Redirect.ALWAYS)
+                .userAgent(Main.getUserAgent())
+                .connectTimeout(Duration.of(10, ChronoUnit.SECONDS))
+                .headersTimeout(Duration.of(10, ChronoUnit.SECONDS))
+                .readTimeout(Duration.of(15, ChronoUnit.SECONDS))
+                .requestTimeout(Duration.of(15, ChronoUnit.SECONDS))
+                .defaultHeader("Accept", "application/json")
+                .defaultHeader("Accept-Encoding", "compress;q=0.5, gzip;q=1.0")
+                .defaultHeader("Content-Type", "application/json")
+                .authenticator(new Authenticator() {
+                    @Override
+                    public PasswordAuthentication requestPasswordAuthenticationInstance(String host, InetAddress addr, int port, String protocol, String prompt, String scheme, URL url, RequestorType reqType) {
+                        return new PasswordAuthentication(baUser, baPassword.toCharArray());
+                    }
+                })
+                .cookieHandler(m_cookieManager);
+        if (!verifySSL && HTTPUtil.getIgnoreSslContext() != null) {
+            builder = builder.sslContext(HTTPUtil.getIgnoreSslContext());
+        }
+        this.httpClient = builder.build();
+    }
+
+//    private static void closeQuietly(final Closeable c) {
+//        if (c == null) {
+//            return;
+//        }
+//        try {
+//            c.close();
+//        } catch (final IOException e) {
+//        }
+//    }
+
+    public DelugeResponse makeRequest(final DelugeRequest delugeRequest) throws DelugeException {
+        int connectionResponseCode;
+        JSONObject jsonResponse;
+
+        final String postData = delugeRequest.toPostData(m_counter++);
+        //final String cookieHeader = getCookieHeader();
+        HttpResponse<String> resp;
+        try {
+            if (postData != null) {
+                resp = httpClient
+                        .send(MutableRequest.POST(m_url, HttpRequest.BodyPublishers.ofString(postData)),
+                                //.header("Cookie", cookieHeader)
+                                //.header("Content-Length", String.valueOf(postData.getBytes(StandardCharsets.UTF_8).length)),
+                                java.net.http.HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            } else {
+                resp = httpClient
+                        .send(MutableRequest.POST(m_url, HttpRequest.BodyPublishers.noBody()),
+                                //.header("Cookie", cookieHeader),
+                                java.net.http.HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            }
+            connectionResponseCode = resp.statusCode();
+            jsonResponse = new JSONObject(resp.body());
+//				List<String> setCookie = resp.headers().allValues("Set-Cookie");
+//				if(!setCookie.isEmpty()){
+//					addCookies(setCookie);
+//				}
+        } catch (final IOException | JSONException e) {
+            throw new DelugeException(e);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+        try {
+            if (jsonResponse.has("error") && !jsonResponse.isNull("error")) {
+                final JSONObject error = jsonResponse.getJSONObject("error");
+                final String message = error.optString("message");
+                final int code = error.optInt("code");
+                final StringBuilder builder = new StringBuilder("Error");
+                if (code >= 0) {
+                    builder.append(" ").append(code);
+                }
+                if (message != null) {
+                    builder.append(": ").append(message);
+                }
+                throw new DelugeException(builder.toString());
+            }
+        } catch (final JSONException e) {
+            throw new DelugeException(e);
+        }
+        return new DelugeResponse(connectionResponseCode, jsonResponse);
+    }
+
+//	private String getCookieHeader() {
+//		StringJoiner joiner = new StringJoiner(",");
+//		final List<HttpCookie> cookies = m_cookieManager.getCookieStore().getCookies();
+//		if (cookies == null) {
+//			return "";
+//		}
+//        for (HttpCookie cookie : cookies) {
+//			joiner.add(cookie.toString());
+//        }
+//		return joiner.toString();
+//	}
+
+//	private void addCookies(final List<String> cookies) {
+//		if (cookies == null) {
+//			return;
+//		}
+//		for (final String cookie : cookies) {
+//			m_cookieManager.getCookieStore().add(null, HttpCookie.parse(cookie).get(0));
+//		}
+//	}
+
+    public DelugeListMethodsResponse listMethods() throws DelugeException {
+        DelugeResponse response = makeRequest(new DelugeRequest("system.listMethods"));
+        return new DelugeListMethodsResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public CheckSessionResponse checkSession() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("auth.check_session"));
+        return new CheckSessionResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public LoginResponse login() throws DelugeException {
+        final DelugeRequest request = new DelugeRequest("auth.login", m_password);
+        final DelugeResponse response = makeRequest(request);
+        return new LoginResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public DeleteSessionResponse deleteSession() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("auth.delete_session"));
+        return new DeleteSessionResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public void registerEventListeners() throws DelugeException {
+        final List<String> events = Arrays.asList("ConfigValueChangedEvent",
+                "NewVersionAvailableEvent",
+                "PluginDisabledEvent",
+                "PluginEnabledEvent",
+                "PreTorrentRemovedEvent",
+                "SessionPausedEvent",
+                "SessionResumedEvent",
+                "SessionStartedEvent",
+                "TorrentAddedEvent",
+                "TorrentFileRenamedEvent",
+                "TorrentFinishedEvent",
+                "TorrentFolderRenamedEvent",
+                "TorrentQueueChangedEvent",
+                "TorrentRemovedEvent",
+                "TorrentResumedEvent",
+                "TorrentStateChangedEvent");
+
+        for (final String event : events) {
+            makeRequest(new DelugeRequest("web.register_event_listener", event));
+        }
+    }
+
+    public ConnectedResponse isConnected() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.connected"));
+        return new ConnectedResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public HostResponse getHosts() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.get_hosts"));
+        return new HostResponse(response.getResponseCode(), response.getResponseData(), false);
+    }
+
+    public HostResponse getHostStatus(final String id) throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.get_host_status", id));
+        return new HostResponse(response.getResponseCode(), response.getResponseData(), true);
+    }
+
+    public ConnectedResponse connect(final String id) throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.connect", id));
+        if (response.getResponseData().isNull("result")) {
+            return new ConnectedResponse(response.getResponseCode(), response.getResponseData(), true);
+        } else {
+            return new ConnectedResponse(response.getResponseCode(), response.getResponseData());
+        }
+    }
+
+    public ConnectedResponse disconnect() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.disconnect"));
+        if (response.getResponseData().isNull("result")) {
+            return new ConnectedResponse(response.getResponseCode(), response.getResponseData(), false);
+        } else {
+            return new ConnectedResponse(response.getResponseCode(), response.getResponseData(), true);
+        }
+    }
+
+    public EventsResponse getEvents() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.get_events"));
+        return new EventsResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public UIResponse updateUI() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("web.update_ui", new JSONArray(Arrays.asList(
+                "queue",
+                "name",
+                "total_size",
+                "state",
+                "progress",
+                "num_seeds",
+                "total_seeds",
+                "num_peers",
+                "total_peers",
+                "download_payload_rate",
+                "upload_payload_rate",
+                "eta",
+                "ratio",
+                "distributed_copies",
+                "is_auto_managed",
+                "time_added",
+                "tracker_host",
+                "save_path",
+                "total_done",
+                "total_uploaded",
+                "max_download_speed",
+                "max_upload_speed",
+                "seeds_peers_ratio"
+        )), new JSONObject()));
+        return new UIResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public PBHActiveTorrentsResponse getActiveTorrents() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.get_active_torrents_info"));
+        return new PBHActiveTorrentsResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public PBHBannedPeersResponse getBannedPeers() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.get_blocklist"));
+        return new PBHBannedPeersResponse(response.getResponseCode(), response.getResponseData());
+    }
+
+    public boolean banPeers(List<String> ips) throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.ban_ips", ips));
+        return !determineResponseError(response);
+    }
+
+    public boolean unbanPeers(List<String> ips) throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.unban_ips", ips));
+        return !determineResponseError(response);
+    }
+
+    public boolean replaceBannedPeers(List<String> ips) throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.replace_blocklist", ips));
+        return !determineResponseError(response);
+    }
+
+    private boolean determineResponseError(DelugeResponse response) {
+        if (response.getResponseData().isNull("error")) {
+            return false;
+        }
+        Object error = response.getResponseData().get("error");
+        if (error instanceof Boolean && !(Boolean) error) {
+            return false;
+        }
+        printError(response);
+        return true;
+    }
+
+    private void printError(DelugeResponse response) {
+        System.out.println(response.getResponseData().toString());
+        JSONObject object = response.getResponseData().getJSONObject("error");
+        log.info("Error when call Deluge RPC: message={}, code={}", object.getString("message"), object.getInt("code"));
+    }
+}
+

--- a/src/main/java/raccoonfink/deluge/DelugeServer.java
+++ b/src/main/java/raccoonfink/deluge/DelugeServer.java
@@ -105,7 +105,8 @@ public class DelugeServer {
         } catch (final IOException | JSONException e) {
             throw new DelugeException(e);
         } catch (InterruptedException e) {
-            throw new RuntimeException(e);
+            Thread.currentThread().interrupt();
+            throw new DelugeException(e);
         }
         try {
             if (jsonResponse.has("error") && !jsonResponse.isNull("error")) {

--- a/src/main/java/raccoonfink/deluge/Host.java
+++ b/src/main/java/raccoonfink/deluge/Host.java
@@ -1,0 +1,54 @@
+package raccoonfink.deluge;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Host {
+    private final String m_id;
+    private final String m_hostname;
+    private final int m_port;
+    private final Status m_status;
+    private final String m_version;
+    public Host(final String id, final String hostname, final int port, final String status, final String version) {
+        m_id = id;
+        m_hostname = hostname;
+        m_port = port;
+        m_status = Status.valueOf(status);
+        m_version = version;
+    }
+
+    public String getId() {
+        return m_id;
+    }
+
+    public String getHostname() {
+        return m_hostname;
+    }
+
+    public int getPort() {
+        return m_port;
+    }
+
+    public Status getStatus() {
+        return m_status;
+    }
+
+    public String getVersion() {
+        return m_version;
+    }
+
+    public JSONObject toJSON() throws JSONException {
+        final JSONObject ret = new JSONObject();
+        ret.put("id", m_id);
+        ret.put("hostname", m_hostname);
+        ret.put("status", m_status);
+        ret.putOpt("version", m_version);
+        return ret;
+    }
+
+    public static enum Status {
+        Offline,
+        Online,
+        Connected
+    }
+}

--- a/src/main/java/raccoonfink/deluge/Statistics.java
+++ b/src/main/java/raccoonfink/deluge/Statistics.java
@@ -1,0 +1,93 @@
+package raccoonfink.deluge;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Statistics {
+
+    private int m_dhtNodes;
+    private int m_downloadProtocolRate;
+    private int m_downloadRate;
+    private int m_freeSpace;
+    private boolean m_incomingConnections;
+    private double m_maxDownload;
+    private int m_maxNumConnections;
+    private double m_maxUpload;
+    private int m_numConnections;
+    private int m_uploadProtocolRate;
+    private int m_uploadRate;
+
+    public Statistics(final JSONObject stats) {
+        m_dhtNodes = stats.optInt("dht_nodes");
+        m_downloadProtocolRate = stats.optInt("download_protocol_rate");
+        m_downloadRate = stats.optInt("download_rate");
+        m_freeSpace = stats.optInt("free_space");
+        m_incomingConnections = stats.optBoolean("has_incoming_connections");
+        m_maxDownload = stats.optDouble("max_download");
+        m_maxNumConnections = stats.optInt("max_num_connections");
+        m_maxUpload = stats.optDouble("max_upload");
+        m_numConnections = stats.optInt("num_connections");
+        m_uploadProtocolRate = stats.optInt("upload_protocol_rate");
+        m_uploadRate = stats.optInt("upload_rate");
+    }
+
+    public int getDHTNodes() {
+        return m_dhtNodes;
+    }
+
+    public int getDownloadProtocolRate() {
+        return m_downloadProtocolRate;
+    }
+
+    public int getDownloadRate() {
+        return m_downloadRate;
+    }
+
+    public int getFreeSpace() {
+        return m_freeSpace;
+    }
+
+    public boolean hasIncomingConnections() {
+        return m_incomingConnections;
+    }
+
+    public double getMaxDownload() {
+        return m_maxDownload;
+    }
+
+    public int getMaxNumConnections() {
+        return m_maxNumConnections;
+    }
+
+    public double getMaxUpload() {
+        return m_maxUpload;
+    }
+
+    public int getNumConnections() {
+        return m_numConnections;
+    }
+
+    public int getUploadProtocolRate() {
+        return m_uploadProtocolRate;
+    }
+
+    public int getUploadRate() {
+        return m_uploadRate;
+    }
+
+    public JSONObject toJSON() throws JSONException {
+        final JSONObject ret = new JSONObject();
+        ret.put("dht_nodes", m_dhtNodes);
+        ret.put("download_protocol_rate", m_downloadProtocolRate);
+        ret.put("download_rate", m_downloadRate);
+        ret.put("free_space", m_freeSpace);
+        ret.put("incoming_connections", m_incomingConnections);
+        ret.put("max_download", m_maxDownload);
+        ret.put("max_num_connections", m_maxNumConnections);
+        ret.put("max_upload", m_maxUpload);
+        ret.put("num_connections", m_numConnections);
+        ret.put("upload_protocol_rate", m_uploadProtocolRate);
+        ret.put("upload_rate", m_uploadRate);
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/Torrent.java
+++ b/src/main/java/raccoonfink/deluge/Torrent.java
@@ -1,0 +1,207 @@
+package raccoonfink.deluge;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+
+public class Torrent implements Comparable<Torrent> {
+    private final String m_key;
+    private double m_distributedCopies;
+    private long m_downloadPayloadRate;
+    private long m_eta;
+    private boolean m_autoManaged;
+    private long m_maxDownloadSpeed;
+    private long m_maxUploadSpeed;
+    private String m_name;
+    private long m_numPeers;
+    private long m_numSeeds;
+    private double m_progress;
+    private long m_queue;
+    private double m_ratio;
+    private String m_savePath;
+    private double m_seedsPeerRatio;
+    private double m_timeAdded;
+    private long m_totalDone;
+    private long m_totalPeers;
+    private long m_totalSeeds;
+    private long m_totalSize;
+    private long m_totalUploaded;
+    private String m_trackerHost;
+    private long m_uploadPayloadRate;
+    private State m_state;
+    public Torrent(final String key, final JSONObject data) {
+        m_key = key;
+        m_distributedCopies = data.optDouble("distributed_copies");
+        m_downloadPayloadRate = data.optLong("download_payload_rate");
+        m_eta = data.optLong("eta");
+        m_autoManaged = data.optBoolean("is_auto_managed");
+        m_maxDownloadSpeed = data.optLong("max_download_speed");
+        m_maxUploadSpeed = data.optLong("max_upload_speed");
+        m_name = data.optString("name");
+        m_numPeers = data.optLong("num_peers");
+        m_numSeeds = data.optLong("num_seeds");
+        m_progress = data.optDouble("progress");
+        m_queue = data.optLong("queue");
+        m_ratio = data.optDouble("ratio");
+        m_savePath = data.optString("save_path");
+        m_seedsPeerRatio = data.optDouble("seeds_peer_ratio");
+        m_timeAdded = data.optDouble("time_added");
+        m_totalDone = data.optLong("total_done");
+        m_totalPeers = data.optLong("total_peers");
+        m_totalSeeds = data.optLong("total_seeds");
+        m_totalSize = data.optLong("total_size");
+        m_totalUploaded = data.optLong("total_uploaded");
+        m_trackerHost = data.optString("tracker_host");
+        m_uploadPayloadRate = data.optLong("upload_payload_rate");
+
+        final String state = data.optString("state");
+        if ("Downloading Metadata".equals(state)) {
+            m_state = State.Downloading_Metadata;
+        } else if ("Checking Resume Data".equals(state)) {
+            m_state = State.Checking_Resume_Data;
+        } else {
+            m_state = State.valueOf(state);
+        }
+    }
+
+    public String getKey() {
+        return m_key;
+    }
+
+    public double getDistributedCopies() {
+        return m_distributedCopies;
+    }
+
+    public long getDownloadPayloadRate() {
+        return m_downloadPayloadRate;
+    }
+
+    public long getEta() {
+        return m_eta;
+    }
+
+    public boolean isAutoManaged() {
+        return m_autoManaged;
+    }
+
+    public long getMaxDownloadSpeed() {
+        return m_maxDownloadSpeed;
+    }
+
+    public long getMaxUploadSpeed() {
+        return m_maxUploadSpeed;
+    }
+
+    public String getName() {
+        return m_name;
+    }
+
+    public long getNumPeers() {
+        return m_numPeers;
+    }
+
+    public long getNumSeeds() {
+        return m_numSeeds;
+    }
+
+    public double getProgress() {
+        return m_progress;
+    }
+
+    public long getQueue() {
+        return m_queue;
+    }
+
+    public double getRatio() {
+        return m_ratio;
+    }
+
+    public String getSavePath() {
+        return m_savePath;
+    }
+
+    public double getSeedsPeerRatio() {
+        return m_seedsPeerRatio;
+    }
+
+    public double getTimeAdded() {
+        return m_timeAdded;
+    }
+
+    public long getTotalDone() {
+        return m_totalDone;
+    }
+
+    public long getTotalPeers() {
+        return m_totalPeers;
+    }
+
+    public long getTotalSeeds() {
+        return m_totalSeeds;
+    }
+
+    public long getTotalSize() {
+        return m_totalSize;
+    }
+
+    public long getTotalUploaded() {
+        return m_totalUploaded;
+    }
+
+    public String getTrackerHost() {
+        return m_trackerHost;
+    }
+
+    public long getUploadPayloadRate() {
+        return m_uploadPayloadRate;
+    }
+
+    public State getState() {
+        return m_state;
+    }
+
+    public int compareTo(final Torrent torrent) {
+        return this.getName().compareTo(torrent.getName());
+    }
+
+    public JSONObject toJSON() throws JSONException {
+        final JSONObject ret = new JSONObject();
+        ret.put("key", m_key);
+        ret.put("distributed_copies", m_distributedCopies);
+        ret.put("download_payload_rate", m_downloadPayloadRate);
+        ret.put("eta", m_eta);
+        ret.put("auto_managed", m_autoManaged);
+        ret.put("max_download_speed", m_maxDownloadSpeed);
+        ret.put("max_upload_speed", m_maxUploadSpeed);
+        ret.put("name", m_name);
+        ret.put("num_peers", m_numPeers);
+        ret.put("num_seeds", m_numSeeds);
+        ret.put("progress", m_progress);
+        ret.put("queue", m_queue);
+        ret.put("ratio", m_ratio);
+        ret.put("save_path", m_savePath);
+        ret.put("seeds_peer_ratio", m_seedsPeerRatio);
+        ret.put("time_added", m_timeAdded);
+        ret.put("total_done", m_totalDone);
+        ret.put("total_peers", m_totalPeers);
+        ret.put("total_seeds", m_totalSeeds);
+        ret.put("total_size", m_totalSize);
+        ret.put("total_uploaded", m_totalUploaded);
+        ret.put("tracker_host", m_trackerHost);
+        ret.put("upload_payload_rate", m_uploadPayloadRate);
+        ret.put("state", m_state);
+        return ret;
+    }
+
+    public static enum State {
+        Queued,
+        Checking,
+        Downloading_Metadata,
+        Downloading,
+        Finished,
+        Seeding,
+        Allocating,
+        Checking_Resume_Data
+    }
+
+}
+

--- a/src/main/java/raccoonfink/deluge/responses/CheckSessionResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/CheckSessionResponse.java
@@ -1,0 +1,30 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+public class CheckSessionResponse extends DelugeResponse {
+    private final boolean m_sessionActive;
+
+    public CheckSessionResponse(final Integer httpResponseCode, final JSONObject result) throws DelugeException {
+        super(httpResponseCode, result);
+
+        if (result != null) {
+            m_sessionActive = result.optBoolean("result");
+        } else {
+            m_sessionActive = false;
+        }
+    }
+
+    public boolean isSessionActive() {
+        return m_sessionActive;
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        ret.put("result", isSessionActive());
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/ConnectedResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/ConnectedResponse.java
@@ -1,0 +1,35 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+public class ConnectedResponse extends DelugeResponse {
+    private final boolean m_connected;
+
+    public ConnectedResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+        try {
+            m_connected = response.getBoolean("result");
+        } catch (final JSONException e) {
+            throw new DelugeException(e);
+        }
+    }
+
+    public ConnectedResponse(final Integer httpResponseCode, final JSONObject response, final boolean isConnected) throws DelugeException {
+        super(httpResponseCode, response);
+        m_connected = isConnected;
+    }
+
+    public boolean isConnected() {
+        return m_connected;
+    }
+
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        ret.put("result", isConnected());
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/DeleteSessionResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/DeleteSessionResponse.java
@@ -1,0 +1,30 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+public class DeleteSessionResponse extends DelugeResponse {
+    private final boolean m_sessionDeleted;
+
+    public DeleteSessionResponse(final Integer httpResponseCode, final JSONObject result) throws DelugeException {
+        super(httpResponseCode, result);
+
+        if (result != null) {
+            m_sessionDeleted = result.optBoolean("result");
+        } else {
+            m_sessionDeleted = false;
+        }
+    }
+
+    public boolean isSessionDeleted() {
+        return m_sessionDeleted;
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        ret.put("result", isSessionDeleted());
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/DelugeListMethodsResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/DelugeListMethodsResponse.java
@@ -1,0 +1,22 @@
+package raccoonfink.deluge.responses;
+
+import lombok.Getter;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+public class DelugeListMethodsResponse extends DelugeResponse {
+    private final List<String> delugeSupportedMethods = new ArrayList<>();
+
+    public DelugeListMethodsResponse(Integer httpResponseCode, JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+        JSONArray jsonArray = response.getJSONArray("result");
+        jsonArray.forEach(object -> {
+            delugeSupportedMethods.add((String) object);
+        });
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/DelugeResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/DelugeResponse.java
@@ -1,0 +1,44 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+public class DelugeResponse {
+
+    private final int m_id;
+    private final int m_responseCode;
+    private final JSONObject m_result;
+
+    public DelugeResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        assert (httpResponseCode != null);
+
+        try {
+            m_id = response.getInt("id");
+        } catch (JSONException e) {
+            throw new DelugeException("Invalid 'id' field in JSON: " + response.toString(), e);
+        }
+        m_responseCode = httpResponseCode.intValue();
+        m_result = response;
+    }
+
+    public int getId() {
+        return m_id;
+    }
+
+    public int getResponseCode() {
+        return m_responseCode;
+    }
+
+    public JSONObject getResponseData() {
+        return m_result;
+    }
+
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = new JSONObject();
+        ret.put("id", getId());
+        ret.put("responseCode", getResponseCode());
+        ret.put("result", JSONObject.NULL);
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/EventsResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/EventsResponse.java
@@ -1,0 +1,43 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeEvent;
+import raccoonfink.deluge.DelugeException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class EventsResponse extends DelugeResponse {
+    private final List<DelugeEvent> m_events = new ArrayList<DelugeEvent>();
+
+    public EventsResponse(final Integer httpResponseCode, final JSONObject result) throws DelugeException {
+        super(httpResponseCode, result);
+
+        if (!result.isNull("result")) {
+            try {
+                final JSONArray res = result.getJSONArray("result");
+                for (int i = 0; i < res.length(); i++) {
+                    m_events.add(new DelugeEvent(res.getJSONArray(i)));
+                }
+            } catch (final JSONException e) {
+                throw new DelugeException(e);
+            }
+        }
+    }
+
+    public List<DelugeEvent> getEvents() {
+        return Collections.unmodifiableList(m_events);
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        for (final DelugeEvent ev : m_events) {
+            ret.append("result", ev.toJSON());
+        }
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/HostResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/HostResponse.java
@@ -1,0 +1,49 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+import raccoonfink.deluge.Host;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class HostResponse extends DelugeResponse {
+    private final List<Host> m_hosts = new ArrayList<Host>();
+
+    public HostResponse(final Integer httpResponseCode, final JSONObject response, final boolean singleResult) throws DelugeException {
+        super(httpResponseCode, response);
+        try {
+            final JSONArray result = response.getJSONArray("result");
+            if (singleResult) {
+                m_hosts.add(getHost(result));
+            } else {
+                for (int i = 0; i < result.length(); i++) {
+                    final JSONArray host = result.getJSONArray(i);
+                    m_hosts.add(getHost(host));
+                }
+            }
+        } catch (final JSONException e) {
+            throw new DelugeException(e);
+        }
+    }
+
+    public List<Host> getHosts() {
+        return Collections.unmodifiableList(m_hosts);
+    }
+
+    private Host getHost(final JSONArray host) throws JSONException {
+        return new Host(host.getString(0), host.getString(1), host.getInt(2), host.getString(3), host.optString(4));
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        for (final Host host : m_hosts) {
+            ret.append("result", host.toJSON());
+        }
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/LoginResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/LoginResponse.java
@@ -1,0 +1,30 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+public class LoginResponse extends DelugeResponse {
+    private final boolean m_loggedIn;
+
+    public LoginResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+
+        if (response != null) {
+            m_loggedIn = response.optBoolean("result");
+        } else {
+            m_loggedIn = false;
+        }
+    }
+
+    public boolean isLoggedIn() {
+        return m_loggedIn;
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        ret.put("result", isLoggedIn());
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/PBHActiveTorrentsResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/PBHActiveTorrentsResponse.java
@@ -1,0 +1,120 @@
+package raccoonfink.deluge.responses;
+
+import com.ghostchu.peerbanhelper.util.JsonUtil;
+import com.google.gson.annotations.SerializedName;
+import com.google.gson.reflect.TypeToken;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+import java.util.List;
+
+@Getter
+public class PBHActiveTorrentsResponse extends DelugeResponse {
+    private List<ActiveTorrentsResponseDTO> activeTorrents;
+
+    public PBHActiveTorrentsResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+        if (response.isNull("result")) {
+            return;
+        }
+        JSONArray jsonArray = response.getJSONArray("result");
+        String resultJson = jsonArray.toString();
+        this.activeTorrents = JsonUtil.getGson().fromJson(resultJson, new TypeToken<List<ActiveTorrentsResponseDTO>>() {
+        }.getType());
+    }
+
+    @NoArgsConstructor
+    @Data
+    public static class ActiveTorrentsResponseDTO {
+
+        @SerializedName("id")
+        private String id;
+        @SerializedName("name")
+        private String name;
+        @SerializedName("info_hash")
+        private String infoHash;
+        @SerializedName("progress")
+        private Double progress;
+        @SerializedName("size")
+        private Long size;
+        @SerializedName("upload_payload_rate")
+        private Integer uploadPayloadRate;
+        @SerializedName("download_payload_rate")
+        private Integer downloadPayloadRate;
+        @SerializedName("peers")
+        private List<PeersDTO> peers;
+
+        @NoArgsConstructor
+        @Data
+        public static class PeersDTO {
+            @SerializedName("ip")
+            private String ip;
+            @SerializedName("port")
+            private Integer port;
+            @SerializedName("peer_id")
+            private String peerId;
+            @SerializedName("client_name")
+            private String clientName;
+            @SerializedName("up_speed")
+            private Integer upSpeed;
+            @SerializedName("down_speed")
+            private Integer downSpeed;
+            @SerializedName("payload_up_speed")
+            private Integer payloadUpSpeed;
+            @SerializedName("payload_down_speed")
+            private Integer payloadDownSpeed;
+            @SerializedName("total_upload")
+            private Integer totalUpload;
+            @SerializedName("total_download")
+            private Integer totalDownload;
+            @SerializedName("progress")
+            private Double progress;
+            @SerializedName("flags")
+            private Integer flags;
+            @SerializedName("source")
+            private Integer source;
+            @SerializedName("local_endpoint_ip")
+            private String localEndpointIp;
+            @SerializedName("local_endpoint_port")
+            private Integer localEndpointPort;
+            @SerializedName("queue_bytes")
+            private Integer queueBytes;
+            @SerializedName("request_timeout")
+            private Integer requestTimeout;
+            @SerializedName("num_hashfails")
+            private Integer numHashfails;
+            @SerializedName("download_queue_length")
+            private Integer downloadQueueLength;
+            @SerializedName("upload_queue_length")
+            private Integer uploadQueueLength;
+            @SerializedName("failcount")
+            private Integer failcount;
+            @SerializedName("downloading_block_index")
+            private Integer downloadingBlockIndex;
+            @SerializedName("downloading_progress")
+            private Integer downloadingProgress;
+            @SerializedName("downloading_total")
+            private Integer downloadingTotal;
+            @SerializedName("connection_type")
+            private Integer connectionType;
+            @SerializedName("send_quota")
+            private Integer sendQuota;
+            @SerializedName("receive_quota")
+            private Integer receiveQuota;
+            @SerializedName("rtt")
+            private Integer rtt;
+            @SerializedName("num_pieces")
+            private Integer numPieces;
+            @SerializedName("download_rate_peak")
+            private Integer downloadRatePeak;
+            @SerializedName("upload_rate_peak")
+            private Integer uploadRatePeak;
+            @SerializedName("progress_ppm")
+            private Integer progressPpm;
+        }
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/PBHBannedPeersResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/PBHBannedPeersResponse.java
@@ -1,0 +1,35 @@
+package raccoonfink.deluge.responses;
+
+import com.ghostchu.peerbanhelper.util.JsonUtil;
+import com.google.gson.annotations.SerializedName;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+import java.util.List;
+
+@Getter
+public class PBHBannedPeersResponse extends DelugeResponse {
+    private BannedPeersResponseDTO bannedPeers;
+
+    public PBHBannedPeersResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+        if (response.isNull("result")) {
+            return;
+        }
+        JSONObject jsonObject = response.getJSONObject("result");
+        String resultJson = jsonObject.toString();
+        this.bannedPeers = JsonUtil.getGson().fromJson(resultJson, BannedPeersResponseDTO.class);
+    }
+
+    @NoArgsConstructor
+    @Data
+    public static class BannedPeersResponseDTO {
+        @SerializedName("size")
+        private Integer size;
+        @SerializedName("ips")
+        private List<String> ips;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/UIResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/UIResponse.java
@@ -1,0 +1,70 @@
+package raccoonfink.deluge.responses;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+import raccoonfink.deluge.Statistics;
+import raccoonfink.deluge.Torrent;
+
+import java.util.Iterator;
+import java.util.Set;
+import java.util.TreeSet;
+
+public class UIResponse extends DelugeResponse {
+    private boolean m_connected = false;
+    private Statistics m_statistics;
+    private Set<Torrent> m_torrents = new TreeSet<Torrent>();
+
+    @SuppressWarnings("rawtypes")
+    public UIResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+
+        if (response == null) {
+            return;
+        }
+
+        try {
+            final JSONObject result = response.getJSONObject("result");
+            m_connected = result.optBoolean("connected");
+
+            m_statistics = new Statistics(result.getJSONObject("stats"));
+
+            final JSONObject torrents = result.optJSONObject("torrents");
+            if (torrents != null) {
+                final Iterator it = torrents.keys();
+                while (it.hasNext()) {
+                    final String key = (String) it.next();
+                    m_torrents.add(new Torrent(key, torrents.getJSONObject(key)));
+
+                }
+            }
+        } catch (final JSONException e) {
+            throw new DelugeException(e);
+        }
+    }
+
+    public boolean isConnected() {
+        return m_connected;
+    }
+
+    public Statistics getStatistics() {
+        return m_statistics;
+    }
+
+    public Set<Torrent> getTorrents() {
+        return m_torrents;
+    }
+
+    @Override
+    public JSONObject toResponseJSON() throws JSONException {
+        final JSONObject ret = super.toResponseJSON();
+        ret.put("connected", m_connected);
+        ret.put("statistics", m_statistics.toJSON());
+        final JSONObject torrents = new JSONObject();
+        ret.put("torrents", torrents);
+        for (final Torrent torrent : m_torrents) {
+            torrents.put(torrent.getKey(), torrent.toJSON());
+        }
+        return ret;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/ssl/EmptyKeyRelaxedTrustSSLContext.java
+++ b/src/main/java/raccoonfink/deluge/ssl/EmptyKeyRelaxedTrustSSLContext.java
@@ -1,0 +1,75 @@
+package raccoonfink.deluge.ssl;
+
+import javax.net.ssl.*;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+
+public final class EmptyKeyRelaxedTrustSSLContext extends SSLContextSpi {
+    public static final String ALGORITHM = "EmptyKeyRelaxedTrust";
+
+    private final SSLContext m_delegate;
+
+    public EmptyKeyRelaxedTrustSSLContext() throws NoSuchAlgorithmException, KeyManagementException {
+        SSLContext customContext = null;
+
+        // Use a blank list of key managers so no SSL keys will be available
+        KeyManager[] keyManager = null;
+        TrustManager[] trustManagers = {
+                new X509TrustManager() {
+                    public void checkClientTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+                        // Perform no checks
+                    }
+
+                    public void checkServerTrusted(final X509Certificate[] chain, final String authType) throws CertificateException {
+                        // Perform no checks
+                    }
+
+                    public X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                }
+        };
+        customContext = SSLContext.getInstance("SSL");
+        customContext.init(keyManager, trustManagers, new SecureRandom());
+
+        m_delegate = customContext;
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine() {
+        return m_delegate.createSSLEngine();
+    }
+
+    @Override
+    protected SSLEngine engineCreateSSLEngine(String arg0, int arg1) {
+        return m_delegate.createSSLEngine(arg0, arg1);
+    }
+
+    @Override
+    protected SSLSessionContext engineGetClientSessionContext() {
+        return m_delegate.getClientSessionContext();
+    }
+
+    @Override
+    protected SSLSessionContext engineGetServerSessionContext() {
+        return m_delegate.getServerSessionContext();
+    }
+
+    @Override
+    protected SSLServerSocketFactory engineGetServerSocketFactory() {
+        return m_delegate.getServerSocketFactory();
+    }
+
+    @Override
+    protected javax.net.ssl.SSLSocketFactory engineGetSocketFactory() {
+        return m_delegate.getSocketFactory();
+    }
+
+    @Override
+    protected void engineInit(KeyManager[] km, TrustManager[] tm, SecureRandom arg2) throws KeyManagementException {
+        // Don't do anything, we've already initialized everything in the constructor
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-config-version: 8
+config-version: 9
 # 客户端设置
 client:
   # 名字，可以自己起，会在日志中显示，只能由字母数字横线组成，数字不能打头
@@ -135,11 +135,8 @@ ip-database:
   database-city: 'GeoLite2-City'
   # GeoIP-City 的数据库名称，默认使用免费版（GeoLite2-ASN），如果您购买了付费的数据库，可以自行替换
   database-asn: 'GeoLite2-ASN'
+# 系统防火墙集成设定
+# 允许不支持 WebAPI 封禁 Peers 的客户端，通过系统防火墙阻断 IP 地址
 firewall-integration:
-  order:
-    - "wf" # Windows Firewall
-    - "ipset" # ipset (Linux)
-    - "ufw" # ufw (Linux)
-    - "firewalld" # firewalld (Linux)
-    - "iptables" # iptables (Linux)
-
+  # 高级 Windows 防火墙（基于动态关键字），需要 Windows 10 或更高版本
+  windows-adv-firewall: true


### PR DESCRIPTION
## 新功能

* Deluge 下载器的支持，需要[安装 Deluge 适配器插件](https://github.com/PBH-BTN/PBH-Adapter-Deluge)
* [WebUI] 封禁列表的客户端名称鼠标悬浮时现在可以显示 PeerID

## 错误修复

* 修复了使用 Windows 安装程序安装的 PeerBanHelper 使用 NoGUI 控制台运行时，输出的文本编码不正确的问题

## 性能改进

* 改进了 BTN 模块匹配 IP 地址的性能