### PR TITLE
v5.0.7

### DIFF
--- a/install4j/lang/custom.utf8
+++ b/install4j/lang/custom.utf8
@@ -4,3 +4,5 @@ launcher.peerbanhelper.nogui=PeerBanHelper(无GUI, 控制台)
 launcher.peerbanhelper.service=PeerBanHelper(服务)
 checkbox.followsystemstartup=登录时自动启动到系统托盘
 peerbanhelper.description=PeerBanHelper
+checkbox.registersystemservice=注册为系统服务
+systemservice.note=将 PeerBanHelper 安装为系统服务时，Windows 系统下配置文件将被存储在 C:\Windows\System32\config\systemprofile\AppData\Local\PeerBanHelper 位置，访问此位置需要您拥有管理员权限。

--- a/install4j/lang/en-US.utf8
+++ b/install4j/lang/en-US.utf8
@@ -4,3 +4,5 @@ launcher.peerbanhelper.nogui=PeerBanHelper(NoGUI, Console)
 launcher.peerbanhelper.service=PeerBanHelper(Service)
 checkbox.followsystemstartup=Boot automatically to the system tray when logged in
 peerbanhelper.description=PeerBanHelper
+checkbox.registersystemservice=Register as system service
+systemservice.note=When you install PeerBanHelper as system service，under Windows operation system, the configuration and files will store at C:\Windows\System32\config\systemprofile\AppData\Local\PeerBanHelper. Access this location will require Administrator privileges.

--- a/install4j/project.install4j
+++ b/install4j/project.install4j
@@ -8,6 +8,9 @@
         <language id="en" customLocalizationFile="./lang/en-US.utf8" />
       </additionalLanguages>
     </languages>
+    <variables>
+      <variable name="registerSystemService" value="registerSystemService" />
+    </variables>
     <jreBundles jdkProviderId="Zulu" release="21/21.0.3" />
   </application>
   <files>
@@ -71,6 +74,19 @@
         <file path="./icon.png" />
       </iconImageFiles>
     </launcher>
+    <launcher name="PeerBanHelper Service" id="70" excludeFromMenu="true" swtApp="true" checkUpdater="true">
+      <executable name="PeerBanHelper-Service" iconSet="true" executableDir="." redirectStderr="false" stderrFile="~/PeerBanHelper/error.log" stdoutFile="~/PeerBanHelper/output.log" executableMode="service" singleInstance="true" checkConsoleParameter="true">
+        <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
+      </executable>
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx386M -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
+        <classPath>
+          <archive location="PeerBanHelper.jar" failOnError="false" />
+        </classPath>
+      </java>
+      <iconImageFiles>
+        <file path="./icon.png" />
+      </iconImageFiles>
+    </launcher>
   </launchers>
   <installerGui>
     <applications>
@@ -82,7 +98,9 @@
                 <serializedBean>
                   <property name="failIfNotObtainedMac" type="boolean" value="false" />
                   <property name="failIfNotObtainedWin" type="boolean" value="false" />
-                  <property name="obtainIfAdminWin" type="boolean" value="false" />
+                  <property name="obtainIfAdminMac" type="boolean" value="true" />
+                  <property name="obtainIfNormalMac" type="boolean" value="true" />
+                  <property name="obtainIfNormalWin" type="boolean" value="true" />
                 </serializedBean>
               </action>
             </actions>
@@ -206,6 +224,47 @@ return console.askOkCancel(message, true);
                   <property name="variableName" type="string">startupWhenLoggedIn</property>
                 </serializedBean>
               </formComponent>
+              <formComponent name="Register system service" id="79" beanClass="com.install4j.runtime.beans.formcomponents.CheckboxComponent">
+                <serializedBean>
+                  <property name="checkboxText" type="string">${i18n:checkbox.registersystemservice}</property>
+                  <property name="variableName" type="string">registerSystemService</property>
+                </serializedBean>
+              </formComponent>
+            </formComponents>
+          </screen>
+          <screen name="Show install as system service note" id="83" beanClass="com.install4j.runtime.beans.screens.DefaultInfoScreen" rollbackBarrierExitCode="0">
+            <condition>context.getBooleanVariable("registerSystemService")</condition>
+            <formComponents>
+              <formComponent id="84" beanClass="com.install4j.runtime.beans.formcomponents.MultilineLabelComponent">
+                <serializedBean>
+                  <property name="labelText" type="string">${i18n:InfoBeforeClickLabel}</property>
+                </serializedBean>
+                <visibilityScript>!context.isConsole()</visibilityScript>
+              </formComponent>
+              <formComponent id="85" beanClass="com.install4j.runtime.beans.formcomponents.HtmlDisplayFormComponent" useExternalParametrization="true" externalParametrizationName="HTML or text display" externalParametrizationMode="include">
+                <serializedBean>
+                  <property name="displayedText" type="string">${i18n:systemservice.note}</property>
+                  <property name="fillVertical" type="boolean" value="true" />
+                  <property name="textSource" type="enum" class="com.install4j.runtime.beans.screens.components.TextSource" value="DIRECT" />
+                </serializedBean>
+                <externalParametrizationPropertyNames>
+                  <propertyName>textSource</propertyName>
+                  <propertyName>displayedText</propertyName>
+                  <propertyName>displayedTextFile</propertyName>
+                  <propertyName>variableName</propertyName>
+                </externalParametrizationPropertyNames>
+              </formComponent>
+              <formComponent id="86" beanClass="com.install4j.runtime.beans.formcomponents.ConsoleHandlerFormComponent">
+                <serializedBean>
+                  <property name="consoleScript">
+                    <object class="com.install4j.api.beans.ScriptProperty">
+                      <property name="value" type="string">console.waitForEnter();
+return true;
+</property>
+                    </object>
+                  </property>
+                </serializedBean>
+              </formComponent>
             </formComponents>
           </screen>
           <screen id="15" beanClass="com.install4j.runtime.beans.screens.InstallationScreen" rollbackBarrier="true" rollbackBarrierExitCode="0">
@@ -260,6 +319,24 @@ return console.askOkCancel(message, true);
                   <property name="itemName" type="string">${compiler:sys.fullName} ${compiler:sys.version}</property>
                 </serializedBean>
               </action>
+              <action id="76" beanClass="com.install4j.runtime.beans.actions.services.InstallServiceAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
+                <serializedBean>
+                  <property name="delayedAutoStart" type="boolean" value="true" />
+                  <property name="launcherId" type="string">70</property>
+                  <property name="macosIdentifier" type="string">com.ghostchu.peerbanhelper.PBHService</property>
+                  <property name="maxRestarts" type="int" value="5" />
+                  <property name="restartOnFailure" type="boolean" value="true" />
+                  <property name="windowsPriority" type="enum" class="com.install4j.runtime.beans.actions.services.WindowsPriority" value="BELOW_NORMAL_PRIORITY_CLASS" />
+                </serializedBean>
+                <condition>context.getBooleanVariable("registerSystemService")</condition>
+              </action>
+              <action id="77" beanClass="com.install4j.runtime.beans.actions.services.StartServiceAction" actionElevationType="elevated" rollbackBarrierExitCode="0">
+                <serializedBean>
+                  <property name="autostartOnly" type="boolean" value="true" />
+                  <property name="launcherId" type="string">70</property>
+                </serializedBean>
+                <condition>context.getBooleanVariable("registerSystemService")</condition>
+              </action>
             </actions>
             <formComponents>
               <formComponent id="16" beanClass="com.install4j.runtime.beans.formcomponents.ProgressComponent">
@@ -289,7 +366,11 @@ return console.askOkCancel(message, true);
           <screen id="23" beanClass="com.install4j.runtime.beans.screens.StartupScreen" rollbackBarrierExitCode="0">
             <actions>
               <action id="33" beanClass="com.install4j.runtime.beans.actions.misc.LoadResponseFileAction" rollbackBarrierExitCode="0" />
-              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0" />
+              <action id="34" beanClass="com.install4j.runtime.beans.actions.misc.RequireInstallerPrivilegesAction" actionElevationType="none" rollbackBarrierExitCode="0">
+                <serializedBean>
+                  <property name="failIfNotObtained" type="boolean" value="false" />
+                </serializedBean>
+              </action>
             </actions>
           </screen>
         </startup>
@@ -578,5 +659,16 @@ return console.askYesNo(message, true);
   <mediaSets>
     <windows name="Windows x64" id="38" architecture="64" />
     <windows name="Windows arm64" id="41" architecture="arm64" />
+    <linuxDeb name="Linux Deb Archive amd64" id="72" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_amd64_${compiler:sys.version}">
+      <variables>
+        <variable name="registerSystemService" value="true" />
+      </variables>
+    </linuxDeb>
+    <linuxDeb name="Linux Deb Archive arm64" id="89" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_aarch64_${compiler:sys.version}">
+      <variables>
+        <variable name="registerSystemService" value="true" />
+      </variables>
+      <jreBundle platform="linux-aarch64" />
+    </linuxDeb>
   </mediaSets>
 </install4j>

--- a/install4j/project.install4j
+++ b/install4j/project.install4j
@@ -659,16 +659,5 @@ return console.askYesNo(message, true);
   <mediaSets>
     <windows name="Windows x64" id="38" architecture="64" />
     <windows name="Windows arm64" id="41" architecture="arm64" />
-    <linuxDeb name="Linux Deb Archive amd64" id="72" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_amd64_${compiler:sys.version}">
-      <variables>
-        <variable name="registerSystemService" value="true" />
-      </variables>
-    </linuxDeb>
-    <linuxDeb name="Linux Deb Archive arm64" id="89" mediaFileName="${compiler:sys.shortName}_${compiler:sys.platform}_aarch64_${compiler:sys.version}">
-      <variables>
-        <variable name="registerSystemService" value="true" />
-      </variables>
-      <jreBundle platform="linux-aarch64" />
-    </linuxDeb>
   </mediaSets>
 </install4j>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>5.0.6</version>
+    <version>5.0.7</version>
     <packaging>takari-jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -141,6 +141,7 @@ public class PeerBanHelperServer {
     }
 
     public void start() throws SQLException {
+        log.info(tlUI(Lang.MOTD, Main.getMeta().getVersion()));
         loadDownloaders();
         registerBanListInvokers();
         registerModules();

--- a/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilitySubmitBans.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilitySubmitBans.java
@@ -52,6 +52,10 @@ public class BtnAbilitySubmitBans implements BtnAbility {
     private void submit() {
         log.info(tlUI(Lang.BTN_SUBMITTING_BANS));
         List<BtnBan> btnPeers = generateBans();
+        if (btnPeers.isEmpty()) {
+            lastReport = System.currentTimeMillis();
+            return;
+        }
         BtnBanPing ping = new BtnBanPing(
                 System.currentTimeMillis(),
                 btnPeers

--- a/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilitySubmitPeers.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilitySubmitPeers.java
@@ -42,6 +42,9 @@ public class BtnAbilitySubmitPeers implements BtnAbility {
     private void submit() {
         log.info(tlUI(Lang.BTN_SUBMITTING_PEERS));
         List<BtnPeer> btnPeers = generatePing();
+        if (btnPeers.isEmpty()) {
+            return;
+        }
         BtnPeerPing ping = new BtnPeerPing(
                 System.currentTimeMillis(),
                 btnPeers

--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -25,6 +25,10 @@ public class ProfileUpdateScript {
         this.conf = conf;
     }
 
+    @UpdateScript(version = 12)
+    public void patchProgressCheckBlocker() {
+        conf.set("module.progress-cheat-blocker.ban-duration", "default");
+    }
     @UpdateScript(version = 11)
     public void reAddXL0019() {
         List<String> bannedPeerIds = conf.getStringList("module.peer-id-blacklist.banned-peer-id");

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
@@ -3,6 +3,7 @@ package com.ghostchu.peerbanhelper.database.dao.impl;
 import com.ghostchu.peerbanhelper.database.Database;
 import com.ghostchu.peerbanhelper.database.dao.AbstractPBHDao;
 import com.ghostchu.peerbanhelper.database.table.HistoryEntity;
+import com.j256.ormlite.dao.GenericRawResults;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -37,14 +38,14 @@ public class HistoryDao extends AbstractPBHDao<HistoryEntity, Long> {
     }
 
     public Map<String, Long> getBannedIps(int n) throws Exception {
-        Timestamp twoWeeksAgo = new Timestamp(Instant.now().minus(14, ChronoUnit.DAYS).toEpochMilli());
-
-        String sql = "SELECT ip, COUNT(*) AS count FROM " + getTableName() + " WHERE banAt >= ? " +
-                "GROUP BY ip ORDER BY count DESC LIMIT " + n;
-
+        Timestamp twoWeeksAgo = new Timestamp(Instant.now().minus(60, ChronoUnit.DAYS).toEpochMilli());
         Map<String, Long> result = new HashMap<>();
-        var banLogs = super.queryRaw(sql, twoWeeksAgo.toString());
-        try (banLogs) {
+        try (GenericRawResults<String[]> banLogs = queryBuilder()
+                .selectRaw("ip, COUNT(*) AS count")
+                .groupBy("ip")
+                .orderBy("count", false)
+                .limit((long) n)
+                .queryRaw()) {
             var results = banLogs.getResults();
             results.forEach(arr -> result.put(arr[0], Long.parseLong(arr[1])));
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
@@ -45,6 +45,7 @@ public class HistoryDao extends AbstractPBHDao<HistoryEntity, Long> {
                 .groupBy("ip")
                 .orderBy("count", false)
                 .limit((long) n)
+                .where().ge("banAt", twoWeeksAgo)
                 .queryRaw()) {
             var results = banLogs.getResults();
             results.forEach(arr -> result.put(arr[0], Long.parseLong(arr[1])));

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/HistoryDao.java
@@ -105,7 +105,7 @@ public class HistoryDao extends AbstractPBHDao<HistoryEntity, Long> {
                 SELECT
                                                  	%field%,
                                                  	COUNT( %field% ) AS ct,
-                                                 	COUNT( %field% ) * 1.0 / ( SELECT COUNT( %field% ) FROM history ) AS percent ,
+                                                 	COUNT( %field% ) * 1.0 / ( SELECT COUNT( * ) FROM history ) AS percent ,
                                                  	torrentName,
                                                  	torrentInfoHash,
                                                  	module

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -23,7 +23,7 @@ module:
   peer-id-blacklist:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 259200000
     # method = 匹配方式
     #  + STARTS_WITH = 匹配开头
     #  + ENDS_WITH = 匹配结尾
@@ -66,7 +66,7 @@ module:
   client-name-blacklist:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 259200000
     banned-client-name:
       #- '{"method":"CONTAINS","content":"xunlei 0019", "hit": "FALSE"}' # 排除新版迅雷（会提供上传，但上传比十分感人 1:2000）
       #- '{"method":"CONTAINS","content":"xunlei 0.0.1.9", "hit": "FALSE"}' # 排除新版迅雷（会提供上传，但上传比十分感人 1:2000）
@@ -125,11 +125,13 @@ module:
     # IPV4 前缀长度，前缀相同的 IP 都被视为同一个用户
     # 64 = 常见的 ISP 为单个接入用户分配的前缀长度
     ipv6-prefix-length: 64
+    # 封禁时长
+    ban-duration: 2592000000
   # IP 地址/端口 封禁
   ip-address-blocker:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 259200000
     # 按 IP 封禁，支持 CIDR，其语法大致如下：
     # ::/64
     # a:b:c:d::a:b/64
@@ -154,7 +156,7 @@ module:
     # 是否启用
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 604800000
     # IPV4 前缀长度
     ipv4: 30 # /32 = 单个 IP，/24 = 整个 ?.?.?.x 段
     # IPV6 前缀长度
@@ -163,12 +165,12 @@ module:
   btn:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 259200000
   # 多拨封禁（实验性功能）
   multi-dialing-blocker:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 1296000000
     # 子网掩码长度
     # IP地址前多少位相同的视为同一个子网，位数越少范围越大，一般不需要修改
     subnet-mask-length: 24
@@ -235,9 +237,9 @@ module:
   ip-address-blocker-rules:
     enabled: true
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
-    ban-duration: default
+    ban-duration: 259200000
     # 检查间隔
-    check-interval: 86400000 # 24小时检查一次 毫秒
+    check-interval: 1296000000 # 24小时检查一次 毫秒
     # 规则列表
     rules:
       # 规则ID（任意）

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -239,7 +239,7 @@ module:
     # 封禁时间，单位：毫秒，使用 default 则跟随全局设置
     ban-duration: 259200000
     # 检查间隔
-    check-interval: 1296000000 # 24小时检查一次 毫秒
+    check-interval: 86400000 # 24小时检查一次 毫秒
     # 规则列表
     rules:
       # 规则ID（任意）


### PR DESCRIPTION
## 错误修复

* 由于默认配置字段丢失，导致新安装的 PBH 的 ProgressCheatBlocker 默认封禁时长为 0 毫秒。调整后跟随全局设置
* 由于 v5 更新后，新的封禁时长起步 14 天，但是 Top15 排行榜只查询最近 15 天的封禁记录，且需要条目数量 > 2，导致事实上此排行榜完全不显示任何内容。现在调整为查询最近 60 天
* 修复因 v5 重构，MOTD 消息丢失，导致只依赖日志信息的情况下，难以判断目前运行的版本信息
* 修复图表菜单过滤 1% 以下的数据开关在除了 PeerID 以外的选项上无效的问题

## 更改

* 对新安装的默认配置文件的各个模块封禁时间进行了调整
* 当无数据上传 BTN 时，不再发起请求

## 新功能

* [Beta] Windows 安装器现在支持安装为系统服务