### PR TITLE
进度检查 - 正确计算同网段内对等体的总上传量

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -25,6 +25,14 @@ public class ProfileUpdateScript {
         this.conf = conf;
     }
 
+    @UpdateScript(version = 16)
+    public void progressCheckerIPv6PrefixLength() {
+        var section = conf.getConfigurationSection("module.progress-cheat-blocker");
+        if (section.getInt("ipv6-prefix-length") == 128) {
+            conf.set("module.progress-cheat-blocker.ipv6-prefix-length", 60);
+        }
+    }
+
     @UpdateScript(version = 15)
     public void addCitiesBanningRule() {
         conf.set("module.ip-address-blocker.cities", List.of("示例海南"));

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -219,7 +219,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         // 累加上传增量
         clientTask.setTrackingUploadedIncreaseTotal(clientTask.getTrackingUploadedIncreaseTotal() + uploadedIncremental);
         // 整个段的增量总计
-        final long prefixTrackingUploadedIncreaseTotal = lastRecordedProgress.stream().mapToLong(task -> task.getTorrentId().equals(torrent.getId()) ? 0 : task.getTrackingUploadedIncreaseTotal()).sum();
+        final long prefixTrackingUploadedIncreaseTotal = lastRecordedProgress.stream().mapToLong(task -> task.getTorrentId().equals(torrent.getId()) ? task.getTrackingUploadedIncreaseTotal() : 0).sum();
         // 获取真实已上传量（下载器报告、PBH上次报告记录，整个段的增量总计，三者取最大）
         final long actualUploaded = Math.max(peer.getUploaded(), Math.max(clientTask.getLastReportUploaded(), prefixTrackingUploadedIncreaseTotal));
         try {

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -1,4 +1,4 @@
-config-version: 15
+config-version: 16
 # Check interval (Timeunit: ms)
 # 检查频率（单位：毫秒）
 check-interval: 5000
@@ -144,7 +144,7 @@ module:
     # IPV6 prefix length, same prefix will trick as a same user
     # 64 = 常见的 ISP 为单个接入用户分配的前缀长度
     # 64 = The common prefix length that ISP allocate for one user
-    ipv6-prefix-length: 128
+    ipv6-prefix-length: 60
     ban-duration: 2592000000
     # 启用持久化记录
     # Enable persist recording


### PR DESCRIPTION
替代 #319 
progressRecorder仍以网段为key，但包含同网段所有的ClientTask
db内持久化储存ip，不保存网段
需要近一步测试

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a method for checking and updating IPv6 prefix length configuration.
	- Enhanced handling of IP addresses for client task management.

- **Bug Fixes**
	- Improved logic for managing maximum weight on specific operations related to IP addresses.

- **Documentation**
	- Updated configuration parameters affecting network behavior and application versioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->