### PR TITLE
PCB 支持下载器名称传递，修复数据覆盖问题

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/Main.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/Main.java
@@ -331,7 +331,7 @@ public class Main {
             return name;
         }
         if (name.length() > 1 && Character.isUpperCase(name.charAt(1)) &&
-                Character.isUpperCase(name.charAt(0))) {
+            Character.isUpperCase(name.charAt(0))) {
             return name;
         }
         char chars[] = name.toCharArray();

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -191,7 +191,7 @@ public class PeerBanHelperServer implements Reloadable {
     }
 
     public Downloader createDownloader(String client, ConfigurationSection downloaderSection) {
-        if(downloaderSection.getString("name") != null){
+        if (downloaderSection.getString("name") != null) {
             downloaderSection.set("name", downloaderSection.getString("name", "").replace(".", "-"));
         }
         Downloader downloader = null;
@@ -208,7 +208,7 @@ public class PeerBanHelperServer implements Reloadable {
     }
 
     public Downloader createDownloader(String client, JsonObject downloaderSection) {
-        if(downloaderSection.get("name") != null){
+        if (downloaderSection.get("name") != null) {
             downloaderSection.addProperty("name", downloaderSection.get("name").getAsString().replace(".", "-"));
         }
         Downloader downloader = null;

--- a/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
@@ -30,6 +30,7 @@ public class MainConfigUpdateScript {
         conf.set("ip-database.account-id", null);
         conf.set("ip-database.license-key", null);
     }
+
     @UpdateScript(version = 17)
     public void windowsEcoQoSApi() {
         conf.set("performance.windows-ecoqos-api", true);

--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -53,7 +53,7 @@ public class ProfileUpdateScript {
             var rule = section.getConfigurationSection(key);
             var url = rule.getString("url", "");
             if (url.equals("https://cdn.jsdelivr.net/gh/PBH-BTN/BTN-Collected-Rules@master/combine/all.txt") ||
-                    url.equals("https://fastly.jsdelivr.net/gh/PBH-BTN/BTN-Collected-Rules@master/combine/all.txt")) {
+                url.equals("https://fastly.jsdelivr.net/gh/PBH-BTN/BTN-Collected-Rules@master/combine/all.txt")) {
                 rule.set("url", "https://bcr.pbh-btn.ghorg.ghostchu-services.top/combine/all.txt");
             }
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
@@ -44,7 +44,7 @@ public class DatabaseHelper {
 
     private void performUpgrade() throws SQLException {
         Dao<MetadataEntity, String> metadata = DaoManager.createDao(getDataSource(), MetadataEntity.class);
-        MetadataEntity version = metadata.createIfNotExists(new MetadataEntity("version", "0"));
+        MetadataEntity version = metadata.createIfNotExists(new MetadataEntity("version", "4"));
         int v = Integer.parseInt(version.getValue());
         if (v < 3) {
             try {
@@ -55,6 +55,11 @@ public class DatabaseHelper {
                 //log.error("Unable to upgrade database schema", err);
             }
             v = 3;
+        }
+        if(v == 3){
+            TableUtils.dropTable(getDataSource(), ProgressCheatBlockerPersistEntity.class, true);
+            TableUtils.createTableIfNotExists(database.getDataSource(), ProgressCheatBlockerPersistEntity.class);
+            v = 4;
         }
         version.setValue(String.valueOf(v));
         metadata.update(version);

--- a/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/DatabaseHelper.java
@@ -56,7 +56,7 @@ public class DatabaseHelper {
             }
             v = 3;
         }
-        if(v == 3){
+        if (v == 3) {
             TableUtils.dropTable(getDataSource(), ProgressCheatBlockerPersistEntity.class, true);
             TableUtils.createTableIfNotExists(database.getDataSource(), ProgressCheatBlockerPersistEntity.class);
             v = 4;

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
@@ -42,7 +42,8 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                         entity.getRewindCounter(),
                         entity.getProgressDifferenceCounter(),
                         entity.getFirstTimeSeen().getTime(),
-                        entity.getLastTimeSeen().getTime()
+                        entity.getLastTimeSeen().getTime(),
+                        entity.getDownloader()
                 )
         ).collect(Collectors.toCollection(CopyOnWriteArrayList::new)); // 可变 List，需要并发安全
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
@@ -64,7 +64,8 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                                     task.getRewindCounter(),
                                     task.getProgressDifferenceCounter(),
                                     new Timestamp(System.currentTimeMillis()),
-                                    new Timestamp(System.currentTimeMillis())
+                                    new Timestamp(System.currentTimeMillis()),
+                                    task.getDownloader()
                             );
                             create(entity);
                         } else {

--- a/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
@@ -33,4 +33,6 @@ public final class ProgressCheatBlockerPersistEntity {
     private Timestamp firstTimeSeen;
     @DatabaseField(canBeNull = false)
     private Timestamp lastTimeSeen;
+    @DatabaseField(canBeNull = false)
+    private String downloader;
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -40,7 +40,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.List;
 
@@ -137,9 +136,9 @@ public class BiglyBT extends AbstractDownloader {
         HttpResponse<String> request;
         try {
             request = httpClient.send(MutableRequest.GET(apiEndpoint + "/downloads?filter="
-                            + BiglyBTDownloadStateConst.ST_DOWNLOADING
-                            + "&filter=" + BiglyBTDownloadStateConst.ST_SEEDING
-                            + "&filter=" + BiglyBTDownloadStateConst.ST_ERROR),
+                                                         + BiglyBTDownloadStateConst.ST_DOWNLOADING
+                                                         + "&filter=" + BiglyBTDownloadStateConst.ST_SEEDING
+                                                         + "&filter=" + BiglyBTDownloadStateConst.ST_ERROR),
                     HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBPeer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBPeer.java
@@ -106,23 +106,23 @@ public final class QBPeer implements Peer {
     @Override
     public String toString() {
         return "SingleTorrentPeer{" +
-                "client='" + client + '\'' +
-                ", connection='" + connection + '\'' +
-                ", country='" + country + '\'' +
-                ", countryCode='" + countryCode + '\'' +
-                ", dlSpeed=" + dlSpeed +
-                ", downloaded=" + downloaded +
-                ", files='" + files + '\'' +
-                ", flags='" + flags + '\'' +
-                ", flagsDesc='" + flagsDesc + '\'' +
-                ", ip='" + ip + '\'' +
-                ", peerIdClient='" + peerIdClient + '\'' +
-                ", port=" + port +
-                ", progress=" + progress +
-                ", relevance=" + relevance +
-                ", upSpeed=" + upSpeed +
-                ", uploaded=" + uploaded +
-                '}';
+               "client='" + client + '\'' +
+               ", connection='" + connection + '\'' +
+               ", country='" + country + '\'' +
+               ", countryCode='" + countryCode + '\'' +
+               ", dlSpeed=" + dlSpeed +
+               ", downloaded=" + downloaded +
+               ", files='" + files + '\'' +
+               ", flags='" + flags + '\'' +
+               ", flagsDesc='" + flagsDesc + '\'' +
+               ", ip='" + ip + '\'' +
+               ", peerIdClient='" + peerIdClient + '\'' +
+               ", port=" + port +
+               ", progress=" + progress +
+               ", relevance=" + relevance +
+               ", upSpeed=" + upSpeed +
+               ", uploaded=" + uploaded +
+               '}';
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/ipdb/IPDB.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/ipdb/IPDB.java
@@ -102,7 +102,7 @@ public class IPDB implements AutoCloseable {
                 if (geoData.getCountry() != null && geoData.getCountry().getIso() != null) {
                     String iso = geoData.getCountry().getIso();
                     if (iso.equalsIgnoreCase("CN") || iso.equalsIgnoreCase("TW")
-                            || iso.equalsIgnoreCase("HK") || iso.equalsIgnoreCase("MO")) {
+                        || iso.equalsIgnoreCase("HK") || iso.equalsIgnoreCase("MO")) {
                         queryGeoCN(address, geoData);
                     }
                 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/RuleFeatureModule.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/RuleFeatureModule.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.module;
 
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.peer.Peer;
 import com.ghostchu.peerbanhelper.torrent.Torrent;
 import org.jetbrains.annotations.NotNull;
@@ -16,7 +17,7 @@ public interface RuleFeatureModule extends FeatureModule {
      * @return 规则检查结果
      */
     @NotNull
-    CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor);
+    CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor);
 
     /**
      * 指示模块的内部处理逻辑是否是线程安全的，如果线程不安全，PeerBanHelper 将在同步块中执行不安全的模块

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.PeerBanHelperServer;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -89,7 +90,7 @@ public class AutoRangeBan extends AbstractRuleFeatureModule implements Reloadabl
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (isHandShaking(peer)) {
             return pass();
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
@@ -4,6 +4,7 @@ import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.btn.BtnNetwork;
 import com.ghostchu.peerbanhelper.btn.BtnRuleParsed;
 import com.ghostchu.peerbanhelper.btn.ability.BtnAbilityRules;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -79,7 +80,7 @@ public class BtnNetworkOnline extends AbstractRuleFeatureModule implements Reloa
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer , @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (manager == null) {
             return BTN_MANAGER_NOT_INITIALIZED;
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
@@ -80,7 +80,7 @@ public class BtnNetworkOnline extends AbstractRuleFeatureModule implements Reloa
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer , @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (manager == null) {
             return BTN_MANAGER_NOT_INITIALIZED;
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ClientNameBlacklist.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ClientNameBlacklist.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -86,7 +87,7 @@ public class ClientNameBlacklist extends AbstractRuleFeatureModule implements Re
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (isHandShaking(peer) && (peer.getClientName() == null || peer.getClientName().isBlank())) {
             return handshaking();
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ExpressionRule.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ExpressionRule.java
@@ -165,7 +165,7 @@ public class ExpressionRule extends AbstractRuleFeatureModule implements Reloada
         return checkResult.get();
     }
 
-    public CheckResult runExpression(Expression expression, @NotNull Torrent torrent, @NotNull Peer peer,@NotNull Downloader downloader,  @NotNull ExecutorService ruleExecuteExecutor) {
+    public CheckResult runExpression(Expression expression, @NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         ExpressionMetadata expressionMetadata = expressions.get(expression);
         return getCache().readCacheButWritePassOnly(this, expression.hashCode() + peer.getCacheKey(), () -> {
             CheckResult result;
@@ -173,7 +173,7 @@ public class ExpressionRule extends AbstractRuleFeatureModule implements Reloada
                 Map<String, Object> env = expression.newEnv();
                 env.put("torrent", torrent);
                 env.put("peer", peer);
-                env.put("downloader",downloader);
+                env.put("downloader", downloader);
                 env.put("cacheable", new AtomicBoolean(false));
                 Object returns;
                 if (expressionMetadata.threadSafe()) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -288,7 +289,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         return getCache().readCacheButWritePassOnly(this, peer.getPeerAddress().getIp(), () -> {
             PeerAddress peerAddress = peer.getPeerAddress();
             if (ports.contains(peerAddress.getPort())) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
@@ -4,6 +4,7 @@ import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.database.dao.impl.RuleSubLogsDao;
 import com.ghostchu.peerbanhelper.database.table.RuleSubInfoEntity;
 import com.ghostchu.peerbanhelper.database.table.RuleSubLogEntity;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.IPBanRuleUpdateType;
@@ -109,7 +110,7 @@ public class IPBlackRuleList extends AbstractRuleFeatureModule implements Reload
     }
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         return getCache().readCacheButWritePassOnly(this, peer.getPeerAddress().getIp(), () -> {
             long t1 = System.currentTimeMillis();
             String ip = peer.getPeerAddress().getIp();

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -137,7 +138,7 @@ public class MultiDialingBlocker extends AbstractRuleFeatureModule implements Re
 
     @Override
     public @NotNull CheckResult shouldBanPeer(
-            @NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+            @NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (isHandShaking(peer)) {
             return handshaking();
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/PeerIdBlacklist.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/PeerIdBlacklist.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -87,7 +88,7 @@ public class PeerIdBlacklist extends AbstractRuleFeatureModule implements Reload
 
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (isHandShaking(peer) && (peer.getPeerId() == null || peer.getPeerId().isBlank())) {
             return handshaking();
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -206,7 +206,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         if (lastRecordedProgress == null) lastRecordedProgress = new CopyOnWriteArrayList<>();
         ClientTask clientTask = lastRecordedProgress.stream().filter(task -> task.getPeerIp().equals(peerIpString)).findFirst().orElse(null);
         if (clientTask == null) {
-            clientTask = new ClientTask(peerIpString, 0d, 0L, 0L, 0, 0, System.currentTimeMillis(), System.currentTimeMillis(),downloader.getName());
+            clientTask = new ClientTask(peerIpString, 0d, 0L, 0L, 0, 0, System.currentTimeMillis(), System.currentTimeMillis(), downloader.getName());
             lastRecordedProgress.add(clientTask);
         }
         long uploadedIncremental; // 上传增量

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.module.impl.rule;
 
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.database.dao.impl.ProgressCheatBlockerPersistDao;
+import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.module.AbstractRuleFeatureModule;
 import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
@@ -180,7 +181,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
 
 
     @Override
-    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull ExecutorService ruleExecuteExecutor) {
+    public @NotNull CheckResult shouldBanPeer(@NotNull Torrent torrent, @NotNull Peer peer, @NotNull Downloader downloader, @NotNull ExecutorService ruleExecuteExecutor) {
         if (isHandShaking(peer)) {
             return handshaking();
         }
@@ -205,7 +206,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         if (lastRecordedProgress == null) lastRecordedProgress = new CopyOnWriteArrayList<>();
         ClientTask clientTask = lastRecordedProgress.stream().filter(task -> task.getPeerIp().equals(peerIpString)).findFirst().orElse(null);
         if (clientTask == null) {
-            clientTask = new ClientTask(peerIpString, 0d, 0L, 0L, 0, 0, System.currentTimeMillis(), System.currentTimeMillis());
+            clientTask = new ClientTask(peerIpString, 0d, 0L, 0L, 0, 0, System.currentTimeMillis(), System.currentTimeMillis(),downloader.getName());
             lastRecordedProgress.add(clientTask);
         }
         long uploadedIncremental; // 上传增量
@@ -330,6 +331,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         private int progressDifferenceCounter;
         private long firstTimeSeen;
         private long lastTimeSeen;
+        private String downloader;
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHPlusController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHPlusController.java
@@ -71,7 +71,7 @@ public class PBHPlusController extends AbstractFeatureModule {
         String key = null;
         if (activationManager.getKeyText().length() > 10) {
             key = activationManager.getKeyText().substring(0, 10) + "******";
-        }else{
+        } else {
             key = activationManager.getKeyText();
         }
         context.json(new StdResp(true, null,

--- a/src/main/java/com/ghostchu/peerbanhelper/text/TranslationComponent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/text/TranslationComponent.java
@@ -42,8 +42,8 @@ public class TranslationComponent {
     @Override
     public String toString() {
         return "TranslationComponent{" +
-                "key='" + key + '\'' +
-                ", params=" + Arrays.toString(params) +
-                '}';
+               "key='" + key + '\'' +
+               ", params=" + Arrays.toString(params) +
+               '}';
     }
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/HTTPUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/HTTPUtil.java
@@ -168,9 +168,9 @@ public class HTTPUtil {
         }
         if (r != null) {
             return r.statusCode() == 500
-                    || r.statusCode() == 502
-                    || r.statusCode() == 503
-                    || r.statusCode() == 504;
+                   || r.statusCode() == 502
+                   || r.statusCode() == 503
+                   || r.statusCode() == 504;
         }
         return false;
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/MsgUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/MsgUtil.java
@@ -44,10 +44,10 @@ public class MsgUtil {
 
     public static String threadInfoToString(ThreadInfo info) {
         StringBuilder sb = new StringBuilder("\"" + info.getThreadName() + "\"" +
-                (info.isDaemon() ? " daemon" : "") +
-                " prio=" + info.getPriority() +
-                " Id=" + info.getThreadId() + " " +
-                info.getThreadState());
+                                             (info.isDaemon() ? " daemon" : "") +
+                                             " prio=" + info.getPriority() +
+                                             " Id=" + info.getThreadId() + " " +
+                                             info.getThreadState());
         if (info.getLockName() != null) {
             sb.append(" on ").append(info.getLockName());
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/encrypt/ActivationKeyUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/encrypt/ActivationKeyUtil.java
@@ -53,7 +53,7 @@ public class ActivationKeyUtil {
             String description = keyData.description;
             if (description != null) {
                 if (description.equalsIgnoreCase("No description")
-                        || description.isBlank()) {
+                    || description.isBlank()) {
                     description = null;
                 }
             }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/rule/ModuleMatchCache.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/rule/ModuleMatchCache.java
@@ -24,8 +24,8 @@ public class ModuleMatchCache {
             .maximumWeight(50000L)
             .weigher((key, value) -> {
                 if (value == AbstractRuleFeatureModule.HANDSHAKING_CHECK_RESULT
-                        || value == AbstractRuleFeatureModule.TEAPOT_CHECK_RESULT
-                        || value == AbstractRuleFeatureModule.OK_CHECK_RESULT) {
+                    || value == AbstractRuleFeatureModule.TEAPOT_CHECK_RESULT
+                    || value == AbstractRuleFeatureModule.OK_CHECK_RESULT) {
                     return 1;
                 }
                 return 5;

--- a/src/main/java/com/ghostchu/peerbanhelper/wrapper/PeerAddress.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/wrapper/PeerAddress.java
@@ -37,9 +37,9 @@ public final class PeerAddress implements Comparable<PeerAddress>, Serializable 
     @Override
     public String toString() {
         return "PeerAddress{" +
-                "ip='" + ip + '\'' +
-                ", port=" + port +
-                '}';
+               "ip='" + ip + '\'' +
+               ", port=" + port +
+               '}';
     }
 
     @Override


### PR DESCRIPTION
更改：

* shouldBanPeer 方法添加 Downloader 参数
* ProgressCheatBlocker 添加 Downloader 名称支持，修复多个下载器同时做种相同种子时，数据相互覆盖的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced database upgrade process to improve version management.
  - Integrated downloader information into various peer banning rules, allowing for more dynamic decision-making.
  - Added a new field in client tasks to track the downloader associated with each task.
  - Introduced a configuration update method for the Windows Eco QoS API to improve performance settings.

- **Bug Fixes**
  - Adjusted database schema management to ensure compatibility with current logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->