### PR TITLE
修复 Transmission 暂停-重启错误

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/Downloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/Downloader.java
@@ -53,6 +53,12 @@ public interface Downloader extends AutoCloseable {
     DownloaderLoginResult login();
 
     /**
+     * 一个执行调度任务的窗口，该方法总是在 banWave 中调用
+     */
+    default void runScheduleTasks() {
+    }
+
+    /**
      * 获取此下载器的所有目前正在活动的 Torrent 列表
      *
      * @return 返回所有活动的 Torrents


### PR DESCRIPTION
## TODO

* [x] 修复 STOP 命令传参错误，导致种子无法重启的问题
* [ ] 重写 Torrent 缓解措施处理代码，目前的 暂停-重启 机制在热门种子上会频繁对种子进行重启操作。然而，每次重启 Transmission 都会向所有 Tracker 重新进行状态更新，这间接的造成了对 Tracker 服务器的 DoS（拒绝服务）攻击