### PR TITLE
在按照上传速度排序相同时，使用下载速度辅助排序

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHDownloaderController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHDownloaderController.java
@@ -223,7 +223,14 @@ public class PBHDownloaderController extends AbstractFeatureModule {
                 .filter(p -> p.getDownloader().equals(downloader.getName()))
                 .map(PeerMetadata::getTorrent)
                 .distinct()
-                .sorted((o1, o2) -> Long.compare(o2.getRtUploadSpeed(), o1.getRtUploadSpeed()))
+                .sorted((o1, o2) -> {
+                    var compare = Long.compare(o2.getRtUploadSpeed(), o1.getRtUploadSpeed());
+                    if (compare != 0) {
+                        return compare;
+                    } else {
+                        return Long.compare(o2.getRtDownloadSpeed(), o1.getRtDownloadSpeed());
+                    }
+                })
                 .toList();
         ctx.json(new StdResp(true, null, torrentWrappers));
     }


### PR DESCRIPTION
此 PR 改进了 #373 的表格排序效果。  
在上传速度相同的情况下，使用下载速度进行辅助排序，以便将较高下载速率的 Torrent 排在列表前面。

![image](https://github.com/user-attachments/assets/94453e46-d680-4026-a0c8-70dd59e63991)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced torrent sorting functionality to consider both upload and download speeds for improved ranking.
- **Bug Fixes**
	- Resolved issues with the previous sorting logic that only prioritized upload speed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->