### PR TITLE
裁剪 PeerID

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -188,10 +188,14 @@ public class BiglyBT extends AbstractDownloader {
         PeerManagerRecord peerManagerRecord = JsonUtil.getGson().fromJson(resp.body(), PeerManagerRecord.class);
         List<Peer> peersList = new ArrayList<>();
         for (PeerRecord peer : peerManagerRecord.getPeers()) {
+            var peerId = new String(ByteUtil.hexToByteArray(peer.getPeerId()), StandardCharsets.ISO_8859_1);
+            if (peerId.length() > 8) {
+                peerId = peerId.substring(0, 8);
+            }
             peersList.add(new PeerImpl(
                     new PeerAddress(peer.getIp(), peer.getPort()),
                     peer.getIp(),
-                    new String(ByteUtil.hexToByteArray(peer.getPeerId()), StandardCharsets.ISO_8859_1),
+                    peerId,
                     peer.getClient(),
                     peer.getStats().getRtDownloadSpeed(),
                     peer.getStats().getTotalReceived(),

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -105,9 +105,13 @@ public class Deluge extends AbstractDownloader {
             for (PBHActiveTorrentsResponse.ActiveTorrentsResponseDTO activeTorrent : this.client.getActiveTorrents().getActiveTorrents()) {
                 List<Peer> peers = new ArrayList<>();
                 for (PBHActiveTorrentsResponse.ActiveTorrentsResponseDTO.PeersDTO peer : activeTorrent.getPeers()) {
+                    var peerId = StrUtil.toStringHex(peer.getPeerId());
+                    if (peerId.length() > 8) {
+                        peerId = peerId.substring(0, 8);
+                    }
                     DelugePeer delugePeer = new DelugePeer(
                             new PeerAddress(peer.getIp(), peer.getPort()),
-                            StrUtil.toStringHex(peer.getPeerId()),
+                            peerId,
                             peer.getClientName(),
                             peer.getTotalDownload(),
                             peer.getPayloadDownSpeed(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced peer identifier handling in the BiglyBT and Deluge components, ensuring that peer IDs are limited to a maximum of 8 characters for improved consistency and robustness in peer identification.
  
- **Bug Fixes**
	- Addressed potential issues with peer ID length during processing, enhancing overall stability of the peer management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->