### PR TITLE
PCB 延迟封禁 Peer

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -27,7 +27,7 @@ public class ProfileUpdateScript {
 
     @UpdateScript(version = 18)
     public void banDelayWait() {
-        conf.set("module.progress-cheat-blocker.max-wait-duration", 180000);
+        conf.set("module.progress-cheat-blocker.max-wait-duration", 30000);
     }
 
     @UpdateScript(version = 17)

--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -25,6 +25,11 @@ public class ProfileUpdateScript {
         this.conf = conf;
     }
 
+    @UpdateScript(version = 18)
+    public void banDelayWait() {
+        conf.set("module.progress-cheat-blocker.max-wait-duration", 180000);
+    }
+
     @UpdateScript(version = 17)
     public void updateProfiles() {
         List<String> bannedPeerIds = conf.getStringList("module.peer-id-blacklist.banned-peer-id");

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
@@ -25,6 +26,7 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
 
     public List<ProgressCheatBlocker.ClientTask> fetchFromDatabase(ProgressCheatBlocker.Client client, Timestamp after) throws SQLException {
         IPAddress address = IPAddressUtil.getIPAddress(client.getPeerPrefix());
+        if(address == null) return Collections.emptyList();
         List<ProgressCheatBlockerPersistEntity> entities = queryBuilder()
                 .where()
                 .eq("torrentId", client.getTorrentId())
@@ -44,7 +46,7 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                         entity.getFirstTimeSeen().getTime(),
                         entity.getLastTimeSeen().getTime(),
                         entity.getDownloader(),
-                        entity.getBanDelayWindowEndAt()
+                        entity.getBanDelayWindowEndAt().getTime()
                 )
         ).collect(Collectors.toCollection(CopyOnWriteArrayList::new)); // 可变 List，需要并发安全
     }
@@ -68,7 +70,7 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                                     new Timestamp(System.currentTimeMillis()),
                                     new Timestamp(System.currentTimeMillis()),
                                     task.getDownloader(),
-                                    task.getBanDelayWindowEndAt()
+                                    new Timestamp(task.getBanDelayWindowEndAt())
                             );
                             create(entity);
                         } else {

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/ProgressCheatBlockerPersistDao.java
@@ -43,7 +43,8 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                         entity.getProgressDifferenceCounter(),
                         entity.getFirstTimeSeen().getTime(),
                         entity.getLastTimeSeen().getTime(),
-                        entity.getDownloader()
+                        entity.getDownloader(),
+                        entity.getBanDelayWindowEndAt()
                 )
         ).collect(Collectors.toCollection(CopyOnWriteArrayList::new)); // 可变 List，需要并发安全
     }
@@ -66,7 +67,8 @@ public class ProgressCheatBlockerPersistDao extends AbstractPBHDao<ProgressCheat
                                     task.getProgressDifferenceCounter(),
                                     new Timestamp(System.currentTimeMillis()),
                                     new Timestamp(System.currentTimeMillis()),
-                                    task.getDownloader()
+                                    task.getDownloader(),
+                                    task.getBanDelayWindowEndAt()
                             );
                             create(entity);
                         } else {

--- a/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
@@ -35,6 +35,6 @@ public final class ProgressCheatBlockerPersistEntity {
     private Timestamp lastTimeSeen;
     @DatabaseField(canBeNull = false)
     private String downloader;
-    @DatabaseField(canBeNull = false)
+    @DatabaseField
     private Long banDelayWindowEndAt;
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
@@ -35,4 +35,6 @@ public final class ProgressCheatBlockerPersistEntity {
     private Timestamp lastTimeSeen;
     @DatabaseField(canBeNull = false)
     private String downloader;
+    @DatabaseField(canBeNull = false)
+    private Long banDelayWindowEndAt;
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/table/ProgressCheatBlockerPersistEntity.java
@@ -35,6 +35,6 @@ public final class ProgressCheatBlockerPersistEntity {
     private Timestamp lastTimeSeen;
     @DatabaseField(canBeNull = false)
     private String downloader;
-    @DatabaseField
-    private Long banDelayWindowEndAt;
+    @DatabaseField(canBeNull = false)
+    private Timestamp banDelayWindowEndAt;
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -298,7 +298,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
             clientTask.setBanDelayWindowEndAt(System.currentTimeMillis() + this.maxWaitDuration);
             return false;
         }
-        return clientTask.getBanDelayWindowEndAt() >= System.currentTimeMillis();
+        return System.currentTimeMillis() >= clientTask.getBanDelayWindowEndAt();
     }
 
     private List<ClientTask> loadClientTasks(Client client) {
@@ -321,7 +321,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         // double = 8
         // int = 4
         // 对象头 = 12
-        return calcStringSize(clientTask.peerIp) + (4 * 8) + 8 + (2 * 4) + 12;
+        return calcStringSize(clientTask.peerIp) + (5 * 8) + 8 + (2 * 4) + 12;
     }
 
     private int calcClientSize(Client client) {

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -1,4 +1,4 @@
-config-version: 17
+config-version: 18
 # Check interval (Timeunit: ms)
 # 检查频率（单位：毫秒）
 check-interval: 5000
@@ -163,6 +163,15 @@ module:
     # 单位：ms 默认值：1209600000 （14 天）
     # Time unit: ms, default: 1209600000 (14 days)
     persist-duration: 1209600000
+    # 封禁前最长等待时间
+    # Max duration before ban
+    # 有时由于下载器网络原因，Peer 可能无法及时同步其进度信息
+    # Sometimes due the network issue, the peer may cannot sync the progress information on time
+    # 当 Peer 达到封禁阈值后开始计时，如果 Peer 未在给定时间内更新自己的进度到正常水平，则将被封禁
+    # When a Peer reached ban condition, the timer will start and Peer will be banned after timer timed out if Peer's progress not update to excepted value on time
+    # 注意：这不适用于进度回退和过量下载
+    # Note: This not suitable for progress rewind or over-download
+    max-wait-duration: 180000
   # IP 地址/端口 封禁
   # IP address/port blacklist
   ip-address-blocker:

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -171,7 +171,7 @@ module:
     # When a Peer reached ban condition, the timer will start and Peer will be banned after timer timed out if Peer's progress not update to excepted value on time
     # 注意：这不适用于进度回退和过量下载
     # Note: This not suitable for progress rewind or over-download
-    max-wait-duration: 180000
+    max-wait-duration: 30000
   # IP 地址/端口 封禁
   # IP address/port blacklist
   ip-address-blocker:


### PR DESCRIPTION
此 PR 用于缓解 #410 所提及的问题。

Peer 并不一定会实时更新自己的进度，这可能是由于以下这些原因：

* 网络原因导致的更新延迟/丢包
* Peer 需要进行文件校验以确认片段无损坏才更新进度（而由于某些原因，这个校验花费了相当长的时间）
* 有的 BT 客户端实现喜欢将更新包攒到一起一起发送
* Seeder 的上传速度太快，以至于对方来不及更新

此 PR 引入了延迟封禁机制：

当一个 Peer 因进度差异达到封禁阈值的时候，PBH 会为其启动一个考察期（这个值默认是 30 秒）。Peer 必须在考察期限内将自己的进度更新到 PBH 所期望的范围内。如果 Peer 没有在考察期内完成更新，或者更新后的值仍然无法达到 PBH 的预期，则封禁将会正式执行。

已经考虑到的一些边界情况：

* 如果 Peer 在考察期限内断开了连接，则考察数据会被持久化保存。这不会造成问题，因为如果 Peer 断开了连接，则下一次连接时报告的进度一定是最新的。

不适用的情况：

* 对于过量下载和进度回退不适用。因为：
  * 1) 过量下载是下载量超过了种子总文件大小一定量，进度无关紧要，只关心总下载量
  * 2) 进度回退说明 Peer 更新了其进度数据，但更新到了一个更小的数据
    * 标准 BT 协议不允许出现这种情况，因此 Peer 的进度只能上涨，除非通过重新连接来刷新会话信息
    * 有一个扩展 [`lt_donthave`](https://www.bittorrent.org/beps/bep_0054.html) 允许 Peer 主动宣告自己不再拥有某些片段。但就如 BEP 所说，其设计为解决 LRU 缓存过期或者资源短缺的导致的片段丢弃。这种丢弃通常不会超出 PBH 的最大允许误差范围。如果有 Peer 使用此扩展丢弃了大量 Pisce，那么即使在传统 BT 实践中，也应视为一个 Bad Peer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a configurable maximum wait duration for client bans, set to 30 seconds.
	- Added a new method to manage peer bans based on specific conditions, improving the handling of client task bans.

- **Bug Fixes**
	- Enhanced tracking of ban delay windows for client tasks, ensuring accurate management of peer interactions.

- **Documentation**
	- Updated configuration file with new parameters and detailed comments for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->