### PR TITLE
添加 Deluge 下载器统计数据支持

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,16 @@
             <groupId>com.maxmind.geoip2</groupId>
             <artifactId>geoip2</artifactId>
             <version>4.2.0</version>
+            <exclusions>
+                <exclusion>
+                    <artifactId>jackson-databind</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>jackson-core</artifactId>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>io.javalin</groupId>

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.downloader.impl.deluge;
 
 import com.ghostchu.peerbanhelper.downloader.AbstractDownloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLoginResult;
+import com.ghostchu.peerbanhelper.downloader.DownloaderStatistics;
 import com.ghostchu.peerbanhelper.peer.Peer;
 import com.ghostchu.peerbanhelper.peer.PeerFlag;
 import com.ghostchu.peerbanhelper.text.Lang;
@@ -25,6 +26,7 @@ import raccoonfink.deluge.DelugeException;
 import raccoonfink.deluge.DelugeServer;
 import raccoonfink.deluge.responses.DelugeListMethodsResponse;
 import raccoonfink.deluge.responses.PBHActiveTorrentsResponse;
+import raccoonfink.deluge.responses.PBHStatisticsResponse;
 
 import java.net.http.HttpClient;
 import java.util.ArrayList;
@@ -176,13 +178,15 @@ public class Deluge extends AbstractDownloader {
     }
 
     @Override
-    public void relaunchTorrentIfNeeded(Collection<Torrent> torrents) {
-
-    }
-
-    @Override
-    public void relaunchTorrentIfNeededByTorrentWrapper(Collection<TorrentWrapper> torrents) {
-
+    public DownloaderStatistics getStatistics() {
+        try {
+            PBHStatisticsResponse resp = this.client.queryStatistics();
+            var dto = resp.getStatistics();
+            return new DownloaderStatistics(dto.getTotalPayloadUpload(), dto.getTotalPayloadDownload());
+        } catch (DelugeException e) {
+            log.error(tlUI(Lang.DOWNLOADER_DELUGE_API_ERROR), e);
+        }
+        return new DownloaderStatistics(0,0);
     }
 
     @Override
@@ -224,92 +228,6 @@ public class Deluge extends AbstractDownloader {
                 connecting, onParole, seed, optimisticUnchoke, snubbed, uploadOnly, endGameMode, holePunched, i2pSocket, utpSocket, sslSocket,
                 rc4Encrypted, plainTextEncrypted, tracker, dht, pex, lsd, resumeData, incoming);
     }
-
-//    private String parseFlag(int peerFlag, int sourceFlag) {
-//        boolean interesting = (peerFlag & (1 << 0)) != 0;
-//        boolean choked = (peerFlag & (1 << 1)) != 0;
-//        boolean remoteInterested = (peerFlag & (1 << 2)) != 0;
-//        boolean remoteChoked = (peerFlag & (1 << 3)) != 0;
-//        boolean supportsExtensions = (peerFlag & (1 << 4)) != 0;
-//        boolean outgoingConnection = (peerFlag & (1 << 5)) != 0;
-//        boolean localConnection = (peerFlag & (1 << 6)) != 0;
-//        boolean handshake = (peerFlag & (1 << 7)) != 0;
-//        boolean connecting = (peerFlag & (1 << 8)) != 0;
-//        boolean onParole = (peerFlag & (1 << 9)) != 0;
-//        boolean seed = (peerFlag & (1 << 10)) != 0;
-//        boolean optimisticUnchoke = (peerFlag & (1 << 11)) != 0;
-//        boolean snubbed = (peerFlag & (1 << 12)) != 0;
-//        boolean uploadOnly = (peerFlag & (1 << 13)) != 0;
-//        boolean endGameMode = (peerFlag & (1 << 14)) != 0;
-//        boolean holePunched = (peerFlag & (1 << 15)) != 0;
-//        boolean i2pSocket = (peerFlag & (1 << 16)) != 0;
-//        boolean utpSocket = (peerFlag & (1 << 17)) != 0;
-//        boolean sslSocket = (peerFlag & (1 << 18)) != 0;
-//        boolean rc4Encrypted = (peerFlag & (1 << 19)) != 0;
-//        boolean plainTextEncrypted = (peerFlag & (1 << 20)) != 0;
-//
-//        boolean tracker = (sourceFlag & (1 << 0)) != 0;
-//        boolean dht = (sourceFlag & (1 << 1)) != 0;
-//        boolean pex = (sourceFlag & (1 << 2)) != 0;
-//        boolean lsd = (sourceFlag & (1 << 3)) != 0;
-//        boolean resumeData = (sourceFlag & (1 << 4)) != 0;
-//        boolean incoming = (sourceFlag & (1 << 5)) != 0;
-//
-//        StringJoiner joiner = new StringJoiner(" ");
-//
-//        if (interesting) {
-//            if (remoteChoked) {
-//                joiner.add("d");
-//            } else {
-//                joiner.add("D");
-//            }
-//        }
-//        if (remoteInterested) {
-//            if (choked) {
-//                joiner.add("u");
-//            } else {
-//                joiner.add("U");
-//            }
-//        }
-//        if (!remoteChoked && !interesting)
-//            joiner.add("K");
-//        if (!choked && !remoteInterested)
-//            joiner.add("?");
-//        if (optimisticUnchoke)
-//            joiner.add("O");
-//        if (snubbed)
-//            joiner.add("S");
-//        if (!localConnection)
-//            joiner.add("I");
-//        if (dht)
-//            joiner.add("H");
-//        if (pex)
-//            joiner.add("X");
-//        if (lsd)
-//            joiner.add("L");
-//        if (rc4Encrypted)
-//            joiner.add("E");
-//        if (plainTextEncrypted)
-//            joiner.add("e");
-//        if (utpSocket)
-//            joiner.add("P");
-//
-//        return joiner.toString();
-//    }
-//
-//
-//    private boolean c2b(char c) {
-//        return c == '1';
-//    }
-//
-//    private String readBits(int i, int bitLength) {
-//        StringBuilder builder = new StringBuilder();
-//        builder.append(Integer.toBinaryString(i));
-//        while (builder.length() < bitLength) {
-//            builder.append("0");
-//        }
-//        return builder.toString();
-//    }
 
     @NoArgsConstructor
     @Data

--- a/src/main/java/raccoonfink/deluge/DelugeServer.java
+++ b/src/main/java/raccoonfink/deluge/DelugeServer.java
@@ -283,6 +283,11 @@ public class DelugeServer {
         return !determineResponseError(response);
     }
 
+    public PBHStatisticsResponse queryStatistics() throws DelugeException {
+        final DelugeResponse response = makeRequest(new DelugeRequest("peerbanhelperadapter.get_session_totals"));
+        return new PBHStatisticsResponse(response.getResponseCode(), response.getResponseData());
+    }
+
     private boolean determineResponseError(DelugeResponse response) {
         if (response.getResponseData().isNull("error")) {
             return false;

--- a/src/main/java/raccoonfink/deluge/responses/PBHStatisticsResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/PBHStatisticsResponse.java
@@ -1,0 +1,85 @@
+package raccoonfink.deluge.responses;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ghostchu.peerbanhelper.util.json.JsonUtil;
+import com.google.gson.reflect.TypeToken;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import raccoonfink.deluge.DelugeException;
+
+import java.util.List;
+
+@Getter
+public class PBHStatisticsResponse extends DelugeResponse {
+    private StatisticsResponseDTO statistics;
+
+    public PBHStatisticsResponse(final Integer httpResponseCode, final JSONObject response) throws DelugeException {
+        super(httpResponseCode, response);
+        if (response.isNull("result")) {
+            return;
+        }
+        JSONArray jsonArray = response.getJSONArray("result");
+        String resultJson = jsonArray.toString();
+        this.statistics = JsonUtil.getGson().fromJson(resultJson, StatisticsResponseDTO.class);
+    }
+
+    @NoArgsConstructor
+    @Data
+    public static class StatisticsResponseDTO{
+        @JsonProperty("stats_last_timestamp")
+        private Long statsLastTimestamp;
+        @JsonProperty("total_payload_download")
+        private Long totalPayloadDownload;
+        @JsonProperty("total_payload_upload")
+        private Long totalPayloadUpload;
+        @JsonProperty("ip_overhead_download")
+        private Long ipOverheadDownload;
+        @JsonProperty("ip_overhead_upload")
+        private Long ipOverheadUpload;
+        @JsonProperty("tracker_download")
+        private Long trackerDownload;
+        @JsonProperty("tracker_upload")
+        private Long trackerUpload;
+        @JsonProperty("dht_download")
+        private Long dhtDownload;
+        @JsonProperty("dht_upload")
+        private Long dhtUpload;
+        @JsonProperty("total_wasted")
+        private Long totalWasted;
+        @JsonProperty("total_download")
+        private Long totalDownload;
+        @JsonProperty("total_upload")
+        private Long totalUpload;
+        @JsonProperty("payload_download_rate")
+        private Double payloadDownloadRate;
+        @JsonProperty("payload_upload_rate")
+        private Double payloadUploadRate;
+        @JsonProperty("download_rate")
+        private Double downloadRate;
+        @JsonProperty("upload_rate")
+        private Double uploadRate;
+        @JsonProperty("ip_overhead_download_rate")
+        private Double ipOverheadDownloadRate;
+        @JsonProperty("ip_overhead_upload_rate")
+        private Double ipOverheadUploadRate;
+        @JsonProperty("dht_download_rate")
+        private Double dhtDownloadRate;
+        @JsonProperty("dht_upload_rate")
+        private Double dhtUploadRate;
+        @JsonProperty("tracker_download_rate")
+        private Double trackerDownloadRate;
+        @JsonProperty("tracker_upload_rate")
+        private Double trackerUploadRate;
+        @JsonProperty("dht_nodes")
+        private Long dhtNodes;
+        @JsonProperty("disk_read_queue")
+        private Long diskReadQueue;
+        @JsonProperty("disk_write_queue")
+        private Long diskWriteQueue;
+        @JsonProperty("peers_count")
+        private Long peersCount;
+    }
+}

--- a/src/main/java/raccoonfink/deluge/responses/PBHStatisticsResponse.java
+++ b/src/main/java/raccoonfink/deluge/responses/PBHStatisticsResponse.java
@@ -2,6 +2,7 @@ package raccoonfink.deluge.responses;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
+import com.google.gson.annotations.SerializedName;
 import com.google.gson.reflect.TypeToken;
 import lombok.Data;
 import lombok.Getter;
@@ -21,7 +22,7 @@ public class PBHStatisticsResponse extends DelugeResponse {
         if (response.isNull("result")) {
             return;
         }
-        JSONArray jsonArray = response.getJSONArray("result");
+        JSONObject jsonArray = response.getJSONObject("result");
         String resultJson = jsonArray.toString();
         this.statistics = JsonUtil.getGson().fromJson(resultJson, StatisticsResponseDTO.class);
     }
@@ -29,57 +30,57 @@ public class PBHStatisticsResponse extends DelugeResponse {
     @NoArgsConstructor
     @Data
     public static class StatisticsResponseDTO{
-        @JsonProperty("stats_last_timestamp")
+        @SerializedName("stats_last_timestamp")
         private Long statsLastTimestamp;
-        @JsonProperty("total_payload_download")
+        @SerializedName("total_payload_download")
         private Long totalPayloadDownload;
-        @JsonProperty("total_payload_upload")
+        @SerializedName("total_payload_upload")
         private Long totalPayloadUpload;
-        @JsonProperty("ip_overhead_download")
+        @SerializedName("ip_overhead_download")
         private Long ipOverheadDownload;
-        @JsonProperty("ip_overhead_upload")
+        @SerializedName("ip_overhead_upload")
         private Long ipOverheadUpload;
-        @JsonProperty("tracker_download")
+        @SerializedName("tracker_download")
         private Long trackerDownload;
-        @JsonProperty("tracker_upload")
+        @SerializedName("tracker_upload")
         private Long trackerUpload;
-        @JsonProperty("dht_download")
+        @SerializedName("dht_download")
         private Long dhtDownload;
-        @JsonProperty("dht_upload")
+        @SerializedName("dht_upload")
         private Long dhtUpload;
-        @JsonProperty("total_wasted")
+        @SerializedName("total_wasted")
         private Long totalWasted;
-        @JsonProperty("total_download")
+        @SerializedName("total_download")
         private Long totalDownload;
-        @JsonProperty("total_upload")
+        @SerializedName("total_upload")
         private Long totalUpload;
-        @JsonProperty("payload_download_rate")
+        @SerializedName("payload_download_rate")
         private Double payloadDownloadRate;
-        @JsonProperty("payload_upload_rate")
+        @SerializedName("payload_upload_rate")
         private Double payloadUploadRate;
-        @JsonProperty("download_rate")
+        @SerializedName("download_rate")
         private Double downloadRate;
-        @JsonProperty("upload_rate")
+        @SerializedName("upload_rate")
         private Double uploadRate;
-        @JsonProperty("ip_overhead_download_rate")
+        @SerializedName("ip_overhead_download_rate")
         private Double ipOverheadDownloadRate;
-        @JsonProperty("ip_overhead_upload_rate")
+        @SerializedName("ip_overhead_upload_rate")
         private Double ipOverheadUploadRate;
-        @JsonProperty("dht_download_rate")
+        @SerializedName("dht_download_rate")
         private Double dhtDownloadRate;
-        @JsonProperty("dht_upload_rate")
+        @SerializedName("dht_upload_rate")
         private Double dhtUploadRate;
-        @JsonProperty("tracker_download_rate")
+        @SerializedName("tracker_download_rate")
         private Double trackerDownloadRate;
-        @JsonProperty("tracker_upload_rate")
+        @SerializedName("tracker_upload_rate")
         private Double trackerUploadRate;
-        @JsonProperty("dht_nodes")
+        @SerializedName("dht_nodes")
         private Long dhtNodes;
-        @JsonProperty("disk_read_queue")
+        @SerializedName("disk_read_queue")
         private Long diskReadQueue;
-        @JsonProperty("disk_write_queue")
+        @SerializedName("disk_write_queue")
         private Long diskWriteQueue;
-        @JsonProperty("peers_count")
+        @SerializedName("peers_count")
         private Long peersCount;
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a method to retrieve downloader performance statistics.
  - Added functionality to query and return statistics related to banned peers.

- **Enhancements**
  - Improved data handling for statistics responses, providing structured access to download/upload metrics.

- **Code Cleanup**
  - Removed unnecessary commented-out code to enhance readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->