### PR TITLE
为 QBEE 实现 getStatistics

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrentEE.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrentEE.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.downloader.impl.qbittorrent;
 
 import com.ghostchu.peerbanhelper.downloader.AbstractDownloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLoginResult;
+import com.ghostchu.peerbanhelper.downloader.DownloaderStatistics;
 import com.ghostchu.peerbanhelper.peer.Peer;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
@@ -181,6 +182,21 @@ public class QBittorrentEE extends AbstractDownloader {
                     detail.getPrivateTorrent() != null && detail.getPrivateTorrent()));
         }
         return torrents;
+    }
+
+    @Override
+    public DownloaderStatistics getStatistics() {
+        HttpResponse<String> request;
+        try {
+            request = httpClient.send(MutableRequest.GET(apiEndpoint + "/sync/maindata"), HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        if (request.statusCode() != 200) {
+            throw new IllegalStateException(tlUI(Lang.DOWNLOADER_FAILED_REQUEST_STATISTICS, request.statusCode(), request.body()));
+        }
+        QBMainData mainData = JsonUtil.getGson().fromJson(request.body(), QBMainData.class);
+        return new DownloaderStatistics(mainData.getServerState().getAlltimeUl(), mainData.getServerState().getAlltimeDl());
     }
 
     @Override


### PR DESCRIPTION
修复忘记合并给 QBEE 的 #408
![image](https://github.com/user-attachments/assets/9c6acc99-49dd-4d60-bb38-b895800d49c2)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve real-time downloader statistics, including total upload and download data.
- **Bug Fixes**
	- Improved error handling for API requests to ensure users receive appropriate feedback on failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->