### PR TITLE
feat: prevent message dismiss on hover

### DIFF
--- a/webui/src/components/plusModal.vue
+++ b/webui/src/components/plusModal.vue
@@ -95,9 +95,9 @@ const submitKey = async (key: string) => {
   loading.value = true
   try {
     await endpointStore.setPlusKey(key)
-    Message.info(t('plus.activeSuccess'))
+    Message.info({ content: t('plus.activeSuccess'), resetOnHover: true })
   } catch (e: unknown) {
-    if (e instanceof Error) Message.error(e.message)
+    if (e instanceof Error) Message.error({ content: e.message, resetOnHover: true })
   } finally {
     loading.value = false
   }

--- a/webui/src/components/settingsModal.vue
+++ b/webui/src/components/settingsModal.vue
@@ -95,13 +95,13 @@ watch(
     if (IncorrectTokenError.is(error) || NeedInitError.is(error)) {
       handleCancel()
     } else if (GetManifestError.is(error)) {
-      if (!error.isManual) Message.error(t(error.message))
+      if (!error.isManual) Message.error({ content: t(error.message), resetOnHover: true })
       if (!showModal.value && error.isApiWrong) {
         showModal.value = true
         initForm()
       }
     } else if (error) {
-      Message.error(`${t('settings.endpoint.error')},error:${error}`)
+      Message.error({ content: `${t('settings.endpoint.error')},error:${error}`, resetOnHover: true })
       if (!showModal.value) {
         showModal.value = true
         initForm()

--- a/webui/src/components/settingsModal.vue
+++ b/webui/src/components/settingsModal.vue
@@ -101,7 +101,10 @@ watch(
         initForm()
       }
     } else if (error) {
-      Message.error({ content: `${t('settings.endpoint.error')},error:${error}`, resetOnHover: true })
+      Message.error({
+        content: `${t('settings.endpoint.error')},error:${error}`,
+        resetOnHover: true
+      })
       if (!showModal.value) {
         showModal.value = true
         initForm()

--- a/webui/src/stores/locale.ts
+++ b/webui/src/stores/locale.ts
@@ -24,7 +24,7 @@ export default function useLocale() {
     i18.locale.value = value
     store.setLocale(value)
     document.querySelector('html')?.setAttribute('lang', value)
-    Message.success(i18.t('navbar.action.locale'))
+    Message.success({ content: i18.t('navbar.action.locale'), resetOnHover: true })
   }
   if (store.localeStore !== '' && i18.availableLocales.includes(store.localeStore)) {
     changeLocale(store.localeStore)

--- a/webui/src/views/banlist/components/banListItem.vue
+++ b/webui/src/views/banlist/components/banListItem.vue
@@ -183,10 +183,16 @@ const emits = defineEmits<{
 const handleUnban = async (address: string) => {
   const { count } = await (await unbanIP(address)).data
   if (!count || count < 1) {
-    Message.error({ content: t('page.banlist.banlist.listItem.unbanUnexcepted'), resetOnHover: true })
+    Message.error({
+      content: t('page.banlist.banlist.listItem.unbanUnexcepted'),
+      resetOnHover: true
+    })
     return false
   } else {
-    Message.success({ content: t('page.banlist.banlist.listItem.unbanSuccess', { count: count }), resetOnHover: true })
+    Message.success({
+      content: t('page.banlist.banlist.listItem.unbanSuccess', { count: count }),
+      resetOnHover: true
+    })
     emits('unban', address)
     return true
   }

--- a/webui/src/views/banlist/components/banListItem.vue
+++ b/webui/src/views/banlist/components/banListItem.vue
@@ -183,10 +183,10 @@ const emits = defineEmits<{
 const handleUnban = async (address: string) => {
   const { count } = await (await unbanIP(address)).data
   if (!count || count < 1) {
-    Message.error(t('page.banlist.banlist.listItem.unbanUnexcepted'))
+    Message.error({ content: t('page.banlist.banlist.listItem.unbanUnexcepted'), resetOnHover: true })
     return false
   } else {
-    Message.success(t('page.banlist.banlist.listItem.unbanSuccess', { count: count }))
+    Message.success({ content: t('page.banlist.banlist.listItem.unbanSuccess', { count: count }), resetOnHover: true })
     emits('unban', address)
     return true
   }

--- a/webui/src/views/dashboard/components/clientStatusCard.vue
+++ b/webui/src/views/dashboard/components/clientStatusCard.vue
@@ -177,12 +177,12 @@ const handleDelete = async () => {
     if (!result.success) {
       throw new Error(result.message)
     } else {
-      Message.success(result.message)
+      Message.success({ content: result.message, resetOnHover: true })
       emits('downloader-deleted')
       return true
     }
   } catch (e: unknown) {
-    if (e instanceof Error) Message.error(e.message)
+    if (e instanceof Error) Message.error({ content: e.message, resetOnHover: true })
     return false
   }
 }

--- a/webui/src/views/dashboard/components/editDownloaderModal.vue
+++ b/webui/src/views/dashboard/components/editDownloaderModal.vue
@@ -118,14 +118,14 @@ const handleBeforeOk = async () => {
       ? await CreateDownloader(form)
       : await UpdateDownloader(oldName.value, form)
     if (result.success) {
-      Message.success(result.message)
+      Message.success({ content: result.message, resetOnHover: true })
       emits('changed')
       return true
     } else {
       throw new Error(result.message)
     }
   } catch (e: unknown) {
-    if (e instanceof Error) Message.error(e.message)
+    if (e instanceof Error) Message.error({ content: e.message, resetOnHover: true })
     return false
   }
 }

--- a/webui/src/views/dashboard/components/torrentList.vue
+++ b/webui/src/views/dashboard/components/torrentList.vue
@@ -74,7 +74,7 @@ const { data, loading } = useRequest(
 
 const handleCopy = (text: string) => {
   copy(text)
-  Message.success(t('page.rule_management.ruleSubscribe.copySuccess'))
+  Message.success({ content: t('page.rule_management.ruleSubscribe.copySuccess'), resetOnHover: true })
 }
 
 const peerList = ref<InstanceType<typeof peerListModal>>()

--- a/webui/src/views/dashboard/components/torrentList.vue
+++ b/webui/src/views/dashboard/components/torrentList.vue
@@ -74,7 +74,10 @@ const { data, loading } = useRequest(
 
 const handleCopy = (text: string) => {
   copy(text)
-  Message.success({ content: t('page.rule_management.ruleSubscribe.copySuccess'), resetOnHover: true })
+  Message.success({
+    content: t('page.rule_management.ruleSubscribe.copySuccess'),
+    resetOnHover: true
+  })
 }
 
 const peerList = ref<InstanceType<typeof peerListModal>>()

--- a/webui/src/views/login/index.vue
+++ b/webui/src/views/login/index.vue
@@ -75,7 +75,7 @@ const handleSubmit: FormInstance['onSubmit'] = async ({ errors, values }) => {
   })
   try {
     await endpointStore.setAuthToken(token, rememberPassword)
-    Message.success(t('login.form.login.success'))
+    Message.success({ content: t('login.form.login.success'), resetOnHover: true })
   } catch (err) {
     loginForm.value?.setFields({
       token: {

--- a/webui/src/views/oobe/components/addDownloader.vue
+++ b/webui/src/views/oobe/components/addDownloader.vue
@@ -82,12 +82,12 @@ const handleTest = async () => {
     })
     if (!testResult.success) throw new Error(testResult.message)
   } catch (e: unknown) {
-    if (e instanceof Error) Message.error(e.message)
+    if (e instanceof Error) Message.error({ content: e.message, resetOnHover: true })
     return false
   } finally {
     testing.value = false
   }
-  Message.success(t('page.oobe.addDownloader.test.success'))
+  Message.success({ content: t('page.oobe.addDownloader.test.success'), resetOnHover: true })
   config.value.valid = true
 }
 </script>

--- a/webui/src/views/rule-management/components/generic/index.vue
+++ b/webui/src/views/rule-management/components/generic/index.vue
@@ -143,7 +143,7 @@ const handleSubmit = async (index: number) => {
       if (!resp.success) {
         throw new Error(resp.message)
       }
-      Message.success(resp.message)
+      Message.success({ content: resp.message, resetOnHover: true })
     } else {
       // update item 先添加，再删除，避免添加失败
       let resp = await addBlackList(dataSource[index].data, type.value)
@@ -154,12 +154,12 @@ const handleSubmit = async (index: number) => {
       if (!resp.success) {
         throw new Error(resp.message)
       }
-      Message.success(resp.message)
+      Message.success({ content: resp.message, resetOnHover: true })
     }
     refresh()
   } catch (e: unknown) {
     if (e instanceof Error) {
-      Message.error(e.message)
+      Message.error({ content: e.message, resetOnHover: true })
     }
   }
 }
@@ -170,11 +170,11 @@ const handleDelete = async (target: number | string) => {
     if (!resp.success) {
       throw new Error(resp.message)
     }
-    Message.success(resp.message)
+    Message.success({ content: resp.message, resetOnHover: true })
     refresh()
     return true
   } catch (e: unknown) {
-    if (e instanceof Error) Message.error(e.message)
+    if (e instanceof Error) Message.error({ content: e.message, resetOnHover: true })
     return false
   }
 }

--- a/webui/src/views/rule-management/components/subscribe/editRuleItemModal.vue
+++ b/webui/src/views/rule-management/components/subscribe/editRuleItemModal.vue
@@ -101,7 +101,7 @@ const handleBeforeOk = async () => {
     // edit
     const result = await UpdateRuleItem(form)
     if (!result.success) {
-      Message.error(result.message)
+      Message.error({ content: result.message, resetOnHover: true })
       return true
     }
     if (callbackFn) callbackFn(form)
@@ -110,7 +110,7 @@ const handleBeforeOk = async () => {
     // new rule item
     const result = await AddRuleItem(form)
     if (!result.success) {
-      Message.error(result.message)
+      Message.error({ content: result.message, resetOnHover: true })
       return true
     }
     if (callbackFn) callbackFn(form)

--- a/webui/src/views/rule-management/components/subscribe/ruleList.vue
+++ b/webui/src/views/rule-management/components/subscribe/ruleList.vue
@@ -45,7 +45,7 @@
               async (newStatus: string | number | boolean) => {
                 const result = await ToggleRuleEnable(record.ruleId, newStatus as boolean)
                 if (!result.success) {
-                  Message.error(result.message)
+                  Message.error({ content: result.message, resetOnHover: true })
                   return false
                 }
                 refresh()
@@ -178,18 +178,18 @@ const handleAdd = () => {
 const handleRefresh = (ruleId: string) =>
   RefreshRule(ruleId).then((result) => {
     if (!result.success) {
-      Message.error(result.message)
+      Message.error({ content: result.message, resetOnHover: true })
     } else {
-      Message.info(result.message)
+      Message.info({ content: result.message, resetOnHover: true })
     }
     refresh()
   })
 const handleDelete = async (ruleId: string) => {
   const result = await DeleteRule(ruleId)
   if (!result.success) {
-    Message.error(result.message)
+    Message.error({ content: result.message, resetOnHover: true })
   } else {
-    Message.success(result.message)
+    Message.success({ content: result.message, resetOnHover: true })
   }
   refresh()
   return true
@@ -200,9 +200,9 @@ const handleUpdateAll = async () => {
   updateAllLoading.value = true
   const result = await UpdateAll()
   if (!result.success) {
-    Message.error(result.message)
+    Message.error({ content: result.message, resetOnHover: true })
   } else {
-    Message.success(result.message)
+    Message.success({ content: result.message, resetOnHover: true })
   }
   refresh()
   updateAllLoading.value = false
@@ -210,7 +210,7 @@ const handleUpdateAll = async () => {
 
 const handleCopy = (text: string) => {
   copy(text)
-  Message.success(t('page.rule_management.ruleSubscribe.copySuccess'))
+  Message.success({ content: t('page.rule_management.ruleSubscribe.copySuccess'), resetOnHover: true })
 }
 </script>
 <style scoped>

--- a/webui/src/views/rule-management/components/subscribe/ruleList.vue
+++ b/webui/src/views/rule-management/components/subscribe/ruleList.vue
@@ -210,7 +210,10 @@ const handleUpdateAll = async () => {
 
 const handleCopy = (text: string) => {
   copy(text)
-  Message.success({ content: t('page.rule_management.ruleSubscribe.copySuccess'), resetOnHover: true })
+  Message.success({
+    content: t('page.rule_management.ruleSubscribe.copySuccess'),
+    resetOnHover: true
+  })
 }
 </script>
 <style scoped>

--- a/webui/src/views/rule-management/components/subscribe/settingsModal.vue
+++ b/webui/src/views/rule-management/components/subscribe/settingsModal.vue
@@ -92,10 +92,10 @@ useRequest(GetCheckInvervalSettings, {
 const handleBeforeOk = async () => {
   const result = await SetCheckInterval(form.checkInterval)
   if (result.success) {
-    Message.success(result.message)
+    Message.success({ content: result.message, resetOnHover: true })
     return true
   }
-  Message.error(result.message)
+  Message.error({ content: result.message, resetOnHover: true })
   return false
 }
 </script>


### PR DESCRIPTION
fix https://github.com/PBH-BTN/pbh-fe/issues/89

看了文档没搞明白怎么全局改默认值，就正则全替换了（
<details>

<summary>要是以后支持改默认值了可以还原回去（？</summary>

替换
Message\.(info|success|warning|error|loading|normal)\(\s*(.+?)\s*\)

Message.$1({ content: $2, resetOnHover: true })

还原
Message\.(info|success|warning|error|loading|normal)\(\s*\{\s*content:\s*(.+?)\s*,\s*resetOnHover:\s*true\s*\}\s*\)

Message.$1($2)

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced message display functionality across various components, allowing messages to reset on hover for improved user interaction.
  
- **Bug Fixes**
	- Improved error and success message handling in multiple components, ensuring clearer user feedback during interactions.

- **Refactor**
	- Standardized message formatting across components to utilize an object structure for better configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->