### PR TITLE
重写 shadowBan 支持检测 & 修复 qb 登录状态检测

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/Preferences.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/Preferences.java
@@ -9,8 +9,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @Data
 public final class Preferences {
-
     @SerializedName("banned_IPs")
     private String bannedIps;
-
+    @SerializedName("shadow_ban_enabled")
+    private Boolean shadowBanEnabled;
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/QBittorrent.java
@@ -102,13 +102,10 @@ public class QBittorrent extends AbstractDownloader {
                                                     .query("password", config.getPassword()).build())
                                     .header("Content-Type", "application/x-www-form-urlencoded")
                             , HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            if (request.statusCode() == 200) {
+            if (request.statusCode() == 200 && isLoggedIn()) {
                 return new DownloaderLoginResult(DownloaderLoginResult.Status.SUCCESS, new TranslationComponent(Lang.STATUS_TEXT_OK));
             }
-            if (request.statusCode() == 403) {
-                return new DownloaderLoginResult(DownloaderLoginResult.Status.INCORRECT_CREDENTIAL, new TranslationComponent(Lang.DOWNLOADER_LOGIN_EXCEPTION, request.body()));
-            }
-            return new DownloaderLoginResult(DownloaderLoginResult.Status.EXCEPTION, new TranslationComponent(Lang.DOWNLOADER_LOGIN_INCORRECT_CRED));
+            return new DownloaderLoginResult(DownloaderLoginResult.Status.INCORRECT_CREDENTIAL, new TranslationComponent(Lang.DOWNLOADER_LOGIN_EXCEPTION, request.body()));
             // return request.statusCode() == 200;
         } catch (Exception e) {
             return new DownloaderLoginResult(DownloaderLoginResult.Status.EXCEPTION, new TranslationComponent(Lang.DOWNLOADER_LOGIN_IO_EXCEPTION, e.getClass().getName() + ": " + e.getMessage()));

--- a/src/main/resources/lang/en_us/messages.yml
+++ b/src/main/resources/lang/en_us/messages.yml
@@ -365,6 +365,6 @@ IN_ECOMODE_SHORT: "🍃EcoQoS"
 IN_ECOMODE_DESCRIPTION: "EcoQoS API load successfully，Windows Efficiency Mode now applied to PeerBanHelper for saving power usage."
 
 DOWNLOADER_TRANSMISSION_DISCOURAGE: "Warning: Use Transmission Adapter is discourage. Frequent starting and stopping of torrents on seeds that are often subject to bans can result in frequent updates to the tracker server, indirectly triggering DoS attacks. This increases the load on the tracker server and may lead to your IP address being banned by the tracker. We encourage you to migrate to other downloaders whenever possible. https://github.com/PBH-BTN/PeerBanHelper/issues/382"
-DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "You are using an official qBittorrent build or a version of qBittorrentEE that does not support ShadowBan. Please turn off the ShadowBan switch."
+DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "Your current version of qBittorrentEE does not support ShadowBan or has not enabled ShadowBan in the qBittorrentEE options. Please turn off the ShadowBan switch."
 
 DOWNLOADER_FAILED_REQUEST_STATISTICS: "Getting stats data from downloader {} failed: {}"

--- a/src/main/resources/lang/messages_fallback.yml
+++ b/src/main/resources/lang/messages_fallback.yml
@@ -365,6 +365,6 @@ IN_ECOMODE_SHORT: "🍃EcoQoS"
 IN_ECOMODE_DESCRIPTION: "EcoQoS API 加载成功，Windows 效率模式已应用至 PeerBanHelper 以降低系统能耗"
 
 DOWNLOADER_TRANSMISSION_DISCOURAGE: "警告：Transmission 适配器已被废弃，不再推荐使用。在频繁发生封禁事件的种子上，频繁启停 Torrent 将导致对 Tracker 服务器的频繁更新，并间接引发 DoS 攻击，这会增加 Tracker 服务器压力并可能导致您的 IP 地址被 Tracker 服务器封禁。我们鼓励您尽可能迁移到其它下载器上。https://github.com/PBH-BTN/PeerBanHelper/issues/382"
-DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "您正在使用普通版本 qBittorrent 或当前版本 qBittorrentEE 不支持 ShadowBan，请关闭 ShadowBan 开关。"
+DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "您当前版本的 qBittorrentEE 不支持 ShadowBan 或未勾选 qBittorrentEE 设置中的 启用 ShadowBan，请关闭 ShadowBan 开关。"
 
 DOWNLOADER_FAILED_REQUEST_STATISTICS: "获取下载器 {} 的统计数据信息失败: {}"

--- a/src/main/resources/lang/zh_cn/messages.yml
+++ b/src/main/resources/lang/zh_cn/messages.yml
@@ -364,6 +364,6 @@ IN_ECOMODE_SHORT: "🍃EcoQoS"
 IN_ECOMODE_DESCRIPTION: "EcoQoS API 加载成功，Windows 效率模式已应用至 PeerBanHelper 以降低系统能耗"
 
 DOWNLOADER_TRANSMISSION_DISCOURAGE: "警告：Transmission 适配器已被废弃，不再推荐使用。在频繁发生封禁事件的种子上，频繁启停 Torrent 将导致对 Tracker 服务器的频繁更新，并间接引发 DoS 攻击，这会增加 Tracker 服务器压力并可能导致您的 IP 地址被 Tracker 服务器封禁。我们鼓励您尽可能迁移到其它下载器上。https://github.com/PBH-BTN/PeerBanHelper/issues/382"
-DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "您正在使用普通版本 qBittorrent 或当前版本 qBittorrentEE 不支持 ShadowBan，请关闭 ShadowBan 开关。"
+DOWNLOADER_QBITTORRENTEE_SHADOWBANAPI_TEST_FAILURE: "您当前版本的 qBittorrentEE 不支持 ShadowBan 或未勾选 qBittorrentEE 设置中的 启用 ShadowBan，请关闭 ShadowBan 开关。"
 
 DOWNLOADER_FAILED_REQUEST_STATISTICS: "获取下载器 {} 的统计数据信息失败: {}"


### PR DESCRIPTION
1. qb auth/login 接口 就算密码错误 也会返回200，因此通过调用 isLoggedIn 判断是否获取到了 cookie
2. qbee transfer/shadowbanPeers 接口 不管有没有在设置里启用都会返回400，所以改为读取 Preferences 里的 shadow_ban_enabled
3. 缓存 shadow_ban_enabled 状态，不要每次调用 login0 都重复判断

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option for shadow banning.
	- Enhanced login functionality to ensure the user is logged in before attempting to log in again.

- **Bug Fixes**
	- Improved error reporting for shadow ban tests and login failures.

- **Documentation**
	- Updated user messages for clarity regarding shadow ban support in qBittorrentEE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->