### PR TITLE
改进 ProgressCheatBlocker

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -239,12 +239,9 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
             if (torrentSize <= 0) {
                 return pass();
             }
-            if (torrentSize < torrentMinimumSize) {
-                return pass();
-            }
 
             // 是否需要进行快速 PCB 测试
-            if (fastPcbTestPercentage > 0) {
+            if (fastPcbTestPercentage > 0 && !fileTooSmall(torrentSize)) {
                 // 只在 <= 0（也就是从未测试过）的情况下对其进行测试
                 if (clientTask.getFastPcbTestExecuteAt() <= 0) {
                     // 如果上传量大于设置的比率，我们主动断开一次连接，封禁 Peer 一段时间，并尽快解除封禁
@@ -281,7 +278,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
             }
             // 计算进度差异
             double difference = Math.abs(actualProgress - clientProgress);
-            if (difference > maximumDifference) {
+            if (difference > maximumDifference && !fileTooSmall(torrentSize)) {
                 if (banPeerIfConditionReached(clientTask)) {
                     clientTask.setProgressDifferenceCounter(clientTask.getProgressDifferenceCounter() + 1);
                     clientTask.setBanDelayWindowEndAt(0L);
@@ -294,7 +291,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
                 }
 
             }
-            if (rewindMaximumDifference > 0) {
+            if (rewindMaximumDifference > 0 && !fileTooSmall(torrentSize)) {
                 double lastRecord = clientTask.getLastReportProgress();
                 double rewind = lastRecord - peer.getProgress();
                 boolean ban = rewind > rewindMaximumDifference;
@@ -319,6 +316,10 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
             clientTask.setLastReportProgress(peer.getProgress());
             progressRecorder.put(client, lastRecordedProgress);
         }
+    }
+
+    private boolean fileTooSmall(long torrentSize) {
+        return torrentSize < torrentMinimumSize;
     }
 
     private boolean banPeerIfConditionReached(ClientTask clientTask) {


### PR DESCRIPTION
在之前的版本中，为了避免文件过小时计算文件下载进度时过于敏感导致误封的情况，在配置文件中定义了一个预设的大小 `minimum-size` 来控制小于此大小的 Torrent 将被完全跳过，这个默认值是 50MB。一旦种子文件大小小于此值，PeerBanHelper 就会完全跳过此 Torrent 的 ProgressCheatBlocker 检查代码。

此功能设计时，吸血情况远没有今天如此复杂。我们发现部分吸血端有时连较小的 Torrent 也没有放过。  
此 PR 改进了 ProgressCheatBlocker 的代码。当 Torrent 小于 `minimum-size` 时，仅跳过部分检查，以下是更改前后的对比：
| 模块名称 | 更改前 | 更改后 |
| ------- | ------ | ----- |
| 超量下载 | 跳过   | 检查  |
| 进度回退 | 跳过   | 跳过  |
| 进度差异 | 跳过   | 跳过 |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to check if torrent sizes are below a specified minimum threshold, enhancing peer management.
  
- **Bug Fixes**
	- Updated conditions for banning peers to include checks for small torrent sizes, preventing unnecessary bans.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->