### PR TITLE
进行数据更新时，使高速缓存失效，以便重新执行规则检查

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/btn/BtnNetwork.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/BtnNetwork.java
@@ -4,6 +4,7 @@ import com.ghostchu.peerbanhelper.PeerBanHelperServer;
 import com.ghostchu.peerbanhelper.btn.ability.*;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
+import com.ghostchu.peerbanhelper.util.rule.ModuleMatchCache;
 import com.github.mizosoft.methanol.Methanol;
 import com.github.mizosoft.methanol.MutableRequest;
 import com.google.gson.JsonObject;
@@ -46,6 +47,8 @@ public class BtnNetwork {
     private String userAgent;
     private PeerBanHelperServer server;
     private final AtomicBoolean configSuccess = new AtomicBoolean(false);
+    @Autowired
+    private ModuleMatchCache moduleMatchCache;
 
     public BtnNetwork(PeerBanHelperServer server, String userAgent, String configUrl, boolean submit, String appId, String appSecret) {
         this.server = server;

--- a/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilityRules.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/ability/BtnAbilityRules.java
@@ -102,6 +102,7 @@ public class BtnAbilityRules extends AbstractBtnAbility {
                             }
                             log.info(tlUI(Lang.BTN_UPDATE_RULES_SUCCESSES, this.btnRule.getVersion()));
                             setLastStatus(true, "Loaded from remote, version: " + this.btnRule.getVersion());
+                            btnNetwork.getModuleMatchCache().invalidateAll();
                         } catch (JsonSyntaxException e) {
                             setLastStatus(false, "Unable parse remote JSON response: " + r.statusCode() + " - " + r.body());
                             log.error("Unable to parse BtnRule as a valid Json object: {}-{}", r.statusCode(), r.body(), e);

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -87,6 +87,7 @@ public class AutoRangeBan extends AbstractRuleFeatureModule implements Reloadabl
         this.ipv4Prefix = getConfig().getInt("ipv4");
         this.ipv6Prefix = getConfig().getInt("ipv6");
         this.banDuration = getConfig().getLong("ban-duration", 0);
+        getCache().invalidateAll();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/BtnNetworkOnline.java
@@ -111,6 +111,7 @@ public class BtnNetworkOnline extends AbstractRuleFeatureModule implements Reloa
 
     public void reloadConfig() {
         this.banDuration = getConfig().getLong("ban-duration", 0);
+        getCache().invalidateAll();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ClientNameBlacklist.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ClientNameBlacklist.java
@@ -84,6 +84,7 @@ public class ClientNameBlacklist extends AbstractRuleFeatureModule implements Re
     private void reloadConfig() {
         this.bannedPeers = RuleParser.parse(getConfig().getStringList("banned-client-name"));
         this.banDuration = getConfig().getLong("ban-duration", 0);
+        getCache().invalidateAll();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ExpressionRule.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ExpressionRule.java
@@ -292,6 +292,7 @@ public class ExpressionRule extends AbstractRuleFeatureModule implements Reloada
             }
         }
         expressions = Map.copyOf(userRules);
+        getCache().invalidateAll();
         log.info(tlUI(Lang.MODULE_EXPRESSION_RULE_COMPILED, expressions.size(), System.currentTimeMillis() - start));
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
@@ -306,6 +306,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         if (getConfig().getBoolean("net-type.datacenter")) {
             this.netTypes.add("数据中心");
         }
+        getCache().invalidateAll();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackList.java
@@ -90,6 +90,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
             context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         }
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleCities(Context context) throws IOException {
@@ -100,6 +101,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         context.status(HttpStatus.CREATED);
         context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         saveConfig();
+        getCache().invalidateAll();
     }
 //
 //    private void handleNetTypeDelete(Context context) throws IOException {
@@ -120,6 +122,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
             context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         }
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleASNDelete(Context context) throws IOException {
@@ -129,6 +132,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
             context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         }
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handlePortDelete(Context context) throws IOException {
@@ -138,6 +142,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
             context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         }
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleIPDelete(Context context) throws IOException {
@@ -150,6 +155,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
             context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         }
         saveConfig();
+        getCache().invalidateAll();
     }
 
 
@@ -161,6 +167,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         ctx.status(HttpStatus.CREATED);
         ctx.json(new StdResp(true, tl(locale(ctx), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleASN(Context ctx) throws IOException {
@@ -169,6 +176,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         ctx.status(HttpStatus.CREATED);
         ctx.json(new StdResp(true, tl(locale(ctx), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         saveConfig();
+        getCache().invalidateAll();
     }
 
 
@@ -178,6 +186,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         ctx.status(HttpStatus.CREATED);
         ctx.json(new StdResp(true, tl(locale(ctx), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleIPPut(Context context) throws IOException {
@@ -186,6 +195,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
         context.status(HttpStatus.CREATED);
         context.json(new StdResp(true, tl(locale(context), Lang.OPERATION_EXECUTE_SUCCESSFULLY), null));
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private void handleIPTest(Context context) throws IOException {
@@ -199,6 +209,7 @@ public class IPBlackList extends AbstractRuleFeatureModule implements Reloadable
                 ipAddress.getCount().toString());
         context.json(new StdResp(true, null, testResult));
         saveConfig();
+        getCache().invalidateAll();
     }
 
     private IPAddress parseIPAddressFromReq(Context ctx) throws IllegalArgumentException {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
@@ -168,6 +168,7 @@ public class IPBlackRuleList extends AbstractRuleFeatureModule implements Reload
                 }
                 log.info(tlUI(Lang.IP_BAN_RULE_UPDATE_FINISH));
             }
+            getCache().invalidateAll();
         } catch (Throwable throwable) {
             log.error("Unable to complete scheduled tasks", throwable);
             rollbarErrorReporter.error(throwable);

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/IPBlackRuleList.java
@@ -150,6 +150,7 @@ public class IPBlackRuleList extends AbstractRuleFeatureModule implements Reload
      * Reload the configuration for this module.
      */
     private void reloadConfig() {
+        getCache().invalidateAll();
         try {
             this.banDuration = getConfig().getLong("ban-duration", 0);
             if (null == ipBanMatchers) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -137,6 +137,7 @@ public class MultiDialingBlocker extends AbstractRuleFeatureModule implements Re
                 maximumSize(TORRENT_PEER_MAX_NUM).
                 softValues().
                 build();
+        getCache().invalidateAll();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -210,8 +210,6 @@ public class MultiDialingBlocker extends AbstractRuleFeatureModule implements Re
                 maximumSize(PEER_MAX_NUM_PER_SUBNET).
                 softValues().
                 build();
-
-        getCache().invalidateAll();
     }
 
     /**

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -210,6 +210,8 @@ public class MultiDialingBlocker extends AbstractRuleFeatureModule implements Re
                 maximumSize(PEER_MAX_NUM_PER_SUBNET).
                 softValues().
                 build();
+
+        getCache().invalidateAll();
     }
 
     /**

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/PeerIdBlacklist.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/PeerIdBlacklist.java
@@ -84,6 +84,7 @@ public class PeerIdBlacklist extends AbstractRuleFeatureModule implements Reload
     public void reloadConfig() {
         this.banDuration = getConfig().getLong("ban-duration", 0);
         this.bannedPeers = RuleParser.parse(getConfig().getStringList("banned-peer-id"));
+        getCache().invalidateAll();
     }
 
 

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -188,6 +188,7 @@ public class ProgressCheatBlocker extends AbstractRuleFeatureModule implements R
         this.maxWaitDuration = getConfig().getLong("max-wait-duration");
         this.fastPcbTestPercentage = getConfig().getDouble("fast-pcb-test-percentage");
         this.fastPcbTestBlockingDuration = getConfig().getLong("fast-pcb-test-block-duration");
+        getCache().invalidateAll();
     }
 
 

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHGeneralController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHGeneralController.java
@@ -3,6 +3,7 @@ package com.ghostchu.peerbanhelper.module.impl.webapi;
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.module.AbstractFeatureModule;
 import com.ghostchu.peerbanhelper.util.context.IgnoreScan;
+import com.ghostchu.peerbanhelper.util.rule.ModuleMatchCache;
 import com.ghostchu.peerbanhelper.web.JavalinWebContainer;
 import com.ghostchu.peerbanhelper.web.Role;
 import com.ghostchu.peerbanhelper.web.wrapper.StdResp;
@@ -20,6 +21,8 @@ import java.util.List;
 public class PBHGeneralController extends AbstractFeatureModule {
     @Autowired
     private JavalinWebContainer webContainer;
+    @Autowired
+    private ModuleMatchCache moduleMatchCache;
 
     @Override
     public boolean isConfigurable() {
@@ -59,6 +62,7 @@ public class PBHGeneralController extends AbstractFeatureModule {
             }
             entryList.add(new ReloadEntry(entryName, r.getStatus().name()));
         });
+        moduleMatchCache.invalidateAll();
         context.json(new StdResp(true, null, entryList));
     }
 


### PR DESCRIPTION
目前当规则更新、用户修改规则时，不会使缓存失效。这样当一个 Peer 通过特定检查后，由于其处于高速缓存中，导致更改不生效。本 PR 在更新数据时，清除所有高速缓存，使得其被重新检查。 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced cache management across multiple components to improve performance and data accuracy.
	- New dependency injection for `ModuleMatchCache` in key classes to streamline cache handling.

- **Bug Fixes**
	- Implemented cache invalidation logic to ensure updated rules and configurations are accurately reflected in the application.

- **Refactor**
	- Simplified logic in several methods for better performance and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->