### PR TITLE
为 V7 更换打包方式

### DIFF
--- a/.github/workflows/build_installers.yml
+++ b/.github/workflows/build_installers.yml
@@ -23,7 +23,7 @@ jobs:
           license: ${{ secrets.INSTALL4J_LICENSE }}
       - name: Make installers
         run: |
-          /opt/install4j/bin/install4jc -L ${{ secrets.INSTALL4J_LICENSE }} -r ${{ steps.java_info.outputs.project_version }} -g -d target/media -D jarPath=$(pwd)/target/PeerBanHelper.jar install4j/project.install4j
+          /opt/install4j/bin/install4jc -L ${{ secrets.INSTALL4J_LICENSE }} -r ${{ steps.java_info.outputs.project_version }} -g -d target/media -D librariesPath=$(pwd)/target/libraries install4j/project.install4j
       # jarPath=$(pwd) 是必须的，install4jc 不知道什么毛病，不支持相对路径，这太诡异了
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build_maven.yml
+++ b/.github/workflows/build_maven.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           name: maven-dist
           path: |
-            target/*.jar
+            target/libraries
         id: project

--- a/.github/workflows/jvm-release.yml
+++ b/.github/workflows/jvm-release.yml
@@ -78,11 +78,14 @@ jobs:
         with:
           name: freebsd-pkg-14.1-dist
           path: target/media
+      - name: "Compress libraries archive"
+        run: |
+          tar zcvf target/libraries target/libraries.tar.gz
       - uses: alexellis/upload-assets@0.4.1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          asset_paths: '["target/PeerBanHelper.jar", "target/media/PeerBanHelper_*", "target/media/peerbanhelper_*", "target/media/peerbanhelper-*"]'
+          asset_paths: '["target/libraries.tar.gz"]'
   Build_Docker:
     permissions:
       contents: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ FROM docker.io/eclipse-temurin:23-jre-alpine
 LABEL maintainer="https://github.com/PBH-BTN/PeerBanHelper"
 USER 0
 ENV TZ=UTC
-ENV JAVA_OPTS="-Xmx512M -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps"
+ENV JAVA_OPTS="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps"
 WORKDIR /app
 VOLUME /tmp
+COPY --from=build build/target/libraries /app/libraries
 COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
 ENV PATH="${JAVA_HOME}/bin:${PATH}"
-ENTRYPOINT ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar PeerBanHelper.jar
+ENTRYPOINT ${JAVA_HOME}/bin/java ${JAVA_OPTS} -cp /app/libraries/* com.ghostchu.peerbanhelper.MainJumpLoader

--- a/Dockerfile-Release
+++ b/Dockerfile-Release
@@ -1,9 +1,10 @@
 FROM docker.io/eclipse-temurin:23-jre-alpine
 LABEL maintainer="https://github.com/PBH-BTN/PeerBanHelper"
+COPY target/libraries /app/libraries
 COPY target/PeerBanHelper.jar /app/PeerBanHelper.jar
 USER 0
 ENV TZ=UTC
-ENV JAVA_OPTS="-Xmx512M -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps"
+ENV JAVA_OPTS="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps"
 WORKDIR /app
 VOLUME /tmp
-ENTRYPOINT ${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar PeerBanHelper.jar
+ENTRYPOINT ${JAVA_HOME}/bin/java ${JAVA_OPTS} -cp /app/libraries/* com.ghostchu.peerbanhelper.MainJumpLoader

--- a/install4j/project.install4j
+++ b/install4j/project.install4j
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <install4j version="10.0.8" transformSequenceNumber="10">
   <directoryPresets config="target/PeerBanHelper.jar" />
-  <application name="PeerBanHelper" applicationId="7121-2388-2769-9582" mediaDir="./output" lzmaCompression="true" shortName="PeerBanHelper" publisher="PBH-BTN Community" publisherWeb="https://github.com/PBH-BTN" version="4.4.1" allPathsRelative="true" backupOnSave="true" autoSave="true" convertDotsToUnderscores="false" convertSpacesToUnderscores="false" macVolumeId="6106cfe6eb875954" javaMinVersion="23" javaMaxVersion="23">
+  <application name="PeerBanHelper" applicationId="7121-2388-2769-9582" mediaDir="./output" lzmaCompression="true" shortName="PeerBanHelper" publisher="PBH-BTN Community" publisherWeb="https://github.com/PBH-BTN" version="7.0.0" allPathsRelative="true" backupOnSave="true" autoSave="true" convertDotsToUnderscores="false" convertSpacesToUnderscores="false" macVolumeId="6106cfe6eb875954" javaMinVersion="23" javaMaxVersion="23">
     <languages languageSelectionInPrincipalLanguage="true">
       <principalLanguage id="zh_CN" customLocalizationFile="./lang/custom.utf8" />
       <additionalLanguages>
@@ -11,6 +11,7 @@
     <variables>
       <variable name="registerSystemService" value="registerSystemService" />
       <variable name="jarPath" value="../target/PeerBanHelper.jar" />
+      <variable name="librariesPath" value="../target/libraries" />
     </variables>
     <jreBundles jdkProviderId="Zulu" release="23/23.0.1" />
   </application>
@@ -19,7 +20,7 @@
       <mountPoint id="24" />
     </mountPoints>
     <entries>
-      <variableEntry mountPoint="24" name="jarPath" />
+      <dirEntry mountPoint="24" file="${compiler:librariesPath}" entryMode="subdir" subDirectory="libraries" />
     </entries>
   </files>
   <launchers>
@@ -29,7 +30,7 @@
       </executable>
       <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -XX:+UseZGC -Xss256K -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true">
         <classPath>
-          <archive location="PeerBanHelper.jar" failOnError="false" />
+          <scanDirectory location="libraries" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
@@ -42,7 +43,7 @@
       </executable>
       <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="swing">
         <classPath>
-          <archive location="PeerBanHelper.jar" failOnError="false" />
+          <scanDirectory location="libraries" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
@@ -55,7 +56,7 @@
       </executable>
       <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="silent">
         <classPath>
-          <archive location="PeerBanHelper.jar" failOnError="false" />
+          <scanDirectory location="libraries" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
@@ -68,7 +69,7 @@
       </executable>
       <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
         <classPath>
-          <archive location="PeerBanHelper.jar" failOnError="false" />
+          <scanDirectory location="libraries" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>
@@ -81,7 +82,7 @@
       </executable>
       <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
         <classPath>
-          <archive location="PeerBanHelper.jar" failOnError="false" />
+          <scanDirectory location="libraries" failOnError="false" />
         </classPath>
       </java>
       <iconImageFiles>

--- a/install4j/project.install4j
+++ b/install4j/project.install4j
@@ -28,7 +28,7 @@
       <executable name="PeerBanHelper-GUI" iconSet="true" executableDir="." redirectStdout="true" executableMode="gui" changeWorkingDirectory="false" singleInstance="true" checkConsoleParameter="true">
         <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
       </executable>
-      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -XX:+UseZGC -Xss256K -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true">
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true">
         <classPath>
           <scanDirectory location="libraries" failOnError="false" />
         </classPath>
@@ -41,7 +41,7 @@
       <executable name="PeerBanHelper-Swing" iconSet="true" executableDir="." redirectStdout="true" executableMode="gui" singleInstance="true" checkConsoleParameter="true">
         <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
       </executable>
-      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="swing">
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="swing">
         <classPath>
           <scanDirectory location="libraries" failOnError="false" />
         </classPath>
@@ -54,7 +54,7 @@
       <executable name="PeerBanHelper-GUI-Silent" iconSet="true" executableDir="." redirectStdout="true" executableMode="gui" singleInstance="true" checkConsoleParameter="true">
         <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
       </executable>
-      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="silent">
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="silent">
         <classPath>
           <scanDirectory location="libraries" failOnError="false" />
         </classPath>
@@ -67,7 +67,7 @@
       <executable name="PeerBanHelper-NoGUI" iconSet="true" executableDir="." redirectStderr="false" executableMode="console" singleInstance="true" checkConsoleParameter="true">
         <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
       </executable>
-      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
         <classPath>
           <scanDirectory location="libraries" failOnError="false" />
         </classPath>
@@ -80,7 +80,7 @@
       <executable name="PeerBanHelper-Service" iconSet="true" executableDir="." redirectStderr="false" stderrFile="~/PeerBanHelper/error.log" stdoutFile="~/PeerBanHelper/output.log" executableMode="service" singleInstance="true" checkConsoleParameter="true">
         <versionInfo include="true" fileDescription="${i18n:peerbanhelper.description}" legalCopyright="PBH-BTN Community - Licensed under GPLv3 licenses. https://www.gnu.org/licenses/quick-guide-gplv3.en.html" internalName="peerbanhelper" />
       </executable>
-      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512K -XX:+UseZGC -XX:+ZGenerational -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
+      <java mainClass="com.ghostchu.peerbanhelper.MainJumpLoader" vmParameters="-Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -Dfile.encoding=UTF-8 -Dpbh.usePlatformConfigLocation=true" arguments="nogui">
         <classPath>
           <scanDirectory location="libraries" failOnError="false" />
         </classPath>

--- a/pom.xml
+++ b/pom.xml
@@ -485,12 +485,6 @@
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
-            <artifactId>javafx-web</artifactId>
-            <version>${javafx.version}</version>
-            <scope>${javafx.scope}</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.openjfx</groupId>
             <artifactId>javafx-swing</artifactId>
             <version>${javafx.version}</version>
             <scope>${javafx.scope}</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <release>${java.version}</release>
+                    <annotationProcessors>
+                        <annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor
+                        </annotationProcessor>
+                    </annotationProcessors>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>
@@ -50,77 +54,65 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-jar-plugin</artifactId>
-                <version>3.0.2</version>
-                <configuration>
-                    <archive>
-                        <manifest>
-                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
-                        </manifest>
-                    </archive>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.apache.logging.log4j</groupId>
-                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
-                        <version>0.1.0</version>
-                    </dependency>
-                </dependencies>
-                <executions>
-                    <execution>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>shade</goal>
-                        </goals>
-                        <configuration>
-                            <finalName>${project.name}</finalName>
-                            <createDependencyReducedPom>true</createDependencyReducedPom>
-                            <minimizeJar>false</minimizeJar>
-                            <createSourcesJar>false</createSourcesJar>
-                            <createTestSourcesJar>false</createTestSourcesJar>
-                            <shadeSourcesContent>true</shadeSourcesContent>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <transformers>
-                                <transformer
-                                        implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
-                                <transformer
-                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                                    <mainClass>${mainClass}</mainClass>
-                                    <manifestEntries>
-                                        <Multi-Release>true</Multi-Release>
-                                    </manifestEntries>
-                                </transformer>
-                            </transformers>
-                            <filters>
-                                <filter>
-                                    <artifact>*:*</artifact>
-                                    <excludes>
-                                        <!--                                            <exclude>META-INF/*.SF</exclude>-->
-                                        <!--                                            <exclude>META-INF/*.DSA</exclude>-->
-                                        <!--                                            <exclude>META-INF/*.RSA</exclude>-->
-                                        <!--                                            <exclude>META-INF/*.kotlin_module</exclude>-->
-                                        <!--                                            <exclude>META-INF/*.txt</exclude>-->
-                                        <!--                                            <exclude>META-INF/proguard/*</exclude>-->
-                                        <!--                                            <exclude>META-INF/services/*</exclude>-->
-                                        <!--                                            <exclude>META-INF/versions/9/*</exclude>-->
-                                        <!--                                            <exclude>*License*</exclude>-->
-                                        <!--                                            <exclude>*LICENSE*</exclude>-->
-                                    </excludes>
-                                </filter>
-                            </filters>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--            <plugin>-->
+            <!--                <groupId>org.apache.maven.plugins</groupId>-->
+            <!--                <artifactId>maven-shade-plugin</artifactId>-->
+            <!--                <version>3.6.0</version>-->
+            <!--                <dependencies>-->
+            <!--                    <dependency>-->
+            <!--                        <groupId>org.apache.logging.log4j</groupId>-->
+            <!--                        <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>-->
+            <!--                        <version>0.1.0</version>-->
+            <!--                    </dependency>-->
+            <!--                </dependencies>-->
+            <!--                <executions>-->
+            <!--                    <execution>-->
+            <!--                        <phase>package</phase>-->
+            <!--                        <goals>-->
+            <!--                            <goal>shade</goal>-->
+            <!--                        </goals>-->
+            <!--                        <configuration>-->
+            <!--                            <finalName>${project.name}</finalName>-->
+            <!--                            <createDependencyReducedPom>true</createDependencyReducedPom>-->
+            <!--                            <minimizeJar>false</minimizeJar>-->
+            <!--                            <createSourcesJar>false</createSourcesJar>-->
+            <!--                            <createTestSourcesJar>false</createTestSourcesJar>-->
+            <!--                            <shadeSourcesContent>true</shadeSourcesContent>-->
+            <!--                            <shadedArtifactAttached>true</shadedArtifactAttached>-->
+            <!--                            <transformers>-->
+            <!--                                <transformer-->
+            <!--                                        implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>-->
+            <!--                                <transformer-->
+            <!--                                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>-->
+            <!--                                <transformer-->
+            <!--                                        implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">-->
+            <!--                                    <mainClass>${mainClass}</mainClass>-->
+            <!--                                    <manifestEntries>-->
+            <!--                                        <Multi-Release>true</Multi-Release>-->
+            <!--                                    </manifestEntries>-->
+            <!--                                </transformer>-->
+            <!--                            </transformers>-->
+            <!--                            <filters>-->
+            <!--                                <filter>-->
+            <!--&lt;!&ndash;                                    <artifact>*:*</artifact>&ndash;&gt;-->
+            <!--                                    <excludes>-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/*.SF</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/*.DSA</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/*.RSA</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/*.kotlin_module</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/*.txt</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/proguard/*</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/services/*</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>META-INF/versions/9/*</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>*License*</exclude>&ndash;&gt;-->
+            <!--                                        &lt;!&ndash;                                            <exclude>*LICENSE*</exclude>&ndash;&gt;-->
+            <!--                                    </excludes>-->
+            <!--                                </filter>-->
+            <!--                            </filters>-->
+            <!--                        </configuration>-->
+            <!--                    </execution>-->
+            <!--                </executions>-->
+            <!--            </plugin>-->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>
@@ -169,28 +161,50 @@
                 <artifactId>javafx-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.0</version>
-                <executions>
-                    <execution>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>build-classpath</goal>
-                        </goals>
-                        <configuration>
-                            <outputProperty>pbh.classpath</outputProperty>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.3.1</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-dependencies</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/libraries</outputDirectory>
+                            <overWriteReleases>false</overWriteReleases>
+                            <overWriteSnapshots>false</overWriteSnapshots>
+                            <overWriteIfNewer>true</overWriteIfNewer>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <configuration>
+                    <outputDirectory>${project.basedir}/target/libraries</outputDirectory>
+                    <archive>
+                        <manifest>
+                            <addClasspath>true</addClasspath>
+                            <mainClass>com.ghostchu.peerbanhelper.MainJumpLoader</mainClass>
+                            <!-- <classpathPrefix>lib</classpathPrefix> -->
+                            <!-- <mainClass>test.org.Cliente</mainClass> -->
+                        </manifest>
+                        <manifestEntries>
+                            <Class-Path>libraries/</Class-Path>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
         </plugins>
         <resources>
             <resource>
@@ -234,23 +248,23 @@
             <id>local-snapshot</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <finalName>
-                                        ${project.name}-SNAPSHOT-${maven.build.timestamp}-${git.commit.id.abbrev}
-                                    </finalName>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
+                    <!--                    <plugin>-->
+                    <!--                        <groupId>org.apache.maven.plugins</groupId>-->
+                    <!--                        <artifactId>maven-shade-plugin</artifactId>-->
+                    <!--                        <executions>-->
+                    <!--                            <execution>-->
+                    <!--                                <phase>package</phase>-->
+                    <!--                                <goals>-->
+                    <!--                                    <goal>shade</goal>-->
+                    <!--                                </goals>-->
+                    <!--                                <configuration>-->
+                    <!--                                    <finalName>-->
+                    <!--                                        ${project.name}-SNAPSHOT-${maven.build.timestamp}-${git.commit.id.abbrev}-->
+                    <!--                                    </finalName>-->
+                    <!--                                </configuration>-->
+                    <!--                            </execution>-->
+                    <!--                        </executions>-->
+                    <!--                    </plugin>-->
                 </plugins>
             </build>
         </profile>
@@ -279,6 +293,7 @@
                                     <installDir>${install4j.home}</installDir>
                                     <projectFile>${project.basedir}/install4j/project.install4j</projectFile>
                                     <variables>
+                                        <librariesPath>${project.basedir}/target/libraries</librariesPath>
                                         <jarPath>${project.basedir}/target/PeerBanHelper.jar</jarPath>
                                     </variables>
                                 </configuration>
@@ -307,6 +322,7 @@
                                     <installDir>${install4j.home}</installDir>
                                     <projectFile>${project.basedir}/install4j/project.install4j</projectFile>
                                     <variables>
+                                        <librariesPath>${project.basedir}/target/libraries</librariesPath>
                                         <jarPath>${project.basedir}/target/PeerBanHelper.jar</jarPath>
                                     </variables>
                                     <!--                                    <incremental>true</incremental>-->
@@ -320,55 +336,6 @@
             <properties>
                 <install4j.home>C:\Program Files\install4j10</install4j.home>
             </properties>
-        </profile>
-        <profile>
-            <!--精简打包，排除不受支持的平台-->
-            <id>thin-sqlite-packaging</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-shade-plugin</artifactId>
-                        <version>3.6.0</version>
-                        <dependencies>
-                            <dependency>
-                                <groupId>org.apache.logging.log4j</groupId>
-                                <artifactId>log4j-transform-maven-shade-plugin-extensions</artifactId>
-                                <version>0.1.0</version>
-                            </dependency>
-                        </dependencies>
-                        <executions>
-                            <execution>
-                                <phase>package</phase>
-                                <goals>
-                                    <goal>shade</goal>
-                                </goals>
-                                <configuration>
-                                    <filters>
-                                        <filter>
-                                            <artifact>*:*</artifact>
-                                            <excludes>
-                                                <exclude>org/sqlite/native/Linux-Android/**</exclude>
-                                                <exclude>org/sqlite/native/Linux/x86/**</exclude>
-                                                <exclude>org/sqlite/native/Linux/arm/**</exclude>
-                                                <exclude>org/sqlite/native/Linux/armv7/**</exclude>
-                                                <exclude>org/sqlite/native/Linux/armv6/**</exclude>
-                                                <exclude>org/sqlite/native/Windows/armv7/**</exclude>
-                                                <exclude>org/sqlite/native/Windows/x86/**</exclude>
-                                                <exclude>org/sqlite/native/Linux-Musl/x86/**</exclude>
-                                                <exclude>org/sqlite/native/FreeBSD/x86/**</exclude>
-                                            </excludes>
-                                        </filter>
-                                    </filters>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,6 @@
                     <source>${java.version}</source>
                     <target>${java.version}</target>
                     <release>${java.version}</release>
-                    <annotationProcessors>
-                        <annotationProcessor>org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor
-                        </annotationProcessor>
-                    </annotationProcessors>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,16 @@
                             <artifactId>lombok</artifactId>
                             <version>1.18.34</version>
                         </path>
+                        <path>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-core</artifactId>
+                            <version>2.24.1</version>
+                        </path>
+                        <path>
+                            <groupId>org.apache.logging.log4j</groupId>
+                            <artifactId>log4j-slf4j2-impl</artifactId>
+                            <version>2.24.1</version>
+                        </path>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>


### PR DESCRIPTION
## TODO

* [ ] 修复 FreeBSD 打包 @Gaojianli 
* [ ] 修复 Debian 打包 @Gaojianli 

过去的版本一直打包为 uber jar，但存在如下问题：

* 碰到类似 Bouncy Castle 这种奇葩的带有数字签名的 jar，在合并打包过程中会触发签名错误，编译会中断。即使编译通过了，运行时一旦触发类加载，依然会出现签名错误崩溃的问题；只能通过运行时动态加载依赖解决问题
* 多平台 native 打包时，无法按需排除依赖文件，只能运行时动态下载加载依赖
* 单 jar 相当大

此 PR 引入了类似 Minecraft 的依赖加载机制（但并不完全是！），将依赖 jar 和主程序 jar 分离开来。除了规避了数字签名问题以外，还能一眼就看出来哪个 jar 很大，方便砍了。

当然，直接替换 jar 的升级方式大抵是死了。

更改后的启动命令类似如下：

```bash
java -Xmx512M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps -cp /app/libraries/* com.ghostchu.peerbanhelper.MainJumpLoader
```

