### PR TITLE
修复 连锁封禁中的ipv6前缀长度被错误限制在32的问题

### DIFF
--- a/webui/src/views/settings/components/profile/components/autoRangeBan.vue
+++ b/webui/src/views/settings/components/profile/components/autoRangeBan.vue
@@ -31,7 +31,7 @@
       :label="t('page.settings.tab.profile.module.autoRangeBan.ipv6Prefix')"
       field="model.ipv6"
     >
-      <a-input-number v-model="model.ipv6" style="width: 100px" :min="0" :max="32"></a-input-number>
+      <a-input-number v-model="model.ipv6" style="width: 100px" :min="0" :max="128"></a-input-number>
     </a-form-item>
   </a-space>
 </template>


### PR DESCRIPTION
<img width="422" alt="image" src="https://github.com/user-attachments/assets/c20ce287-53fc-4932-8ff3-e1ff7487424e">
