### PR TITLE
限制 PCB 视为同一用户的前缀数值

### DIFF
--- a/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
+++ b/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
@@ -75,14 +75,14 @@
       field="model.ipv4_prefix_length"
       :tooltip="t('page.settings.tab.profile.module.progressCheatBlocker.ipprefixLength.tips')"
     >
-      <a-input-number v-model="model.ipv4_prefix_length" style="width: 100px"></a-input-number>
+      <a-input-number v-model="model.ipv4_prefix_length" style="width: 100px" :min="0" :max="32"></a-input-number>
     </a-form-item>
     <a-form-item
       :label="t('page.settings.tab.profile.module.progressCheatBlocker.ipv6prefixlength')"
       field="model.ipv6_prefix_length"
       :tooltip="t('page.settings.tab.profile.module.progressCheatBlocker.ipprefixLength.tips')"
     >
-      <a-input-number v-model="model.ipv6_prefix_length" style="width: 100px"></a-input-number>
+      <a-input-number v-model="model.ipv6_prefix_length" style="width: 100px" :min="0" :max="128"></a-input-number>
     </a-form-item>
     <a-form-item
       :label="t('page.settings.tab.profile.module.progressCheatBlocker.banDuration')"


### PR DESCRIPTION
限制 PCB 视为同一用户的前缀数值

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced input validation constraints for IPv4 and IPv6 prefix length fields to ensure values are within acceptable ranges (0-32 for IPv4 and 0-128 for IPv6). 

These changes enhance user experience by preventing invalid input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->