### PR TITLE
修复Issues #530 #601

### DIFF
--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -28,7 +28,7 @@
       </template>
       <template #scroll-loading>
         <a-spin
-          v-if="loading && !loadingMore"
+          v-if="loading && list.length === 0"
           :style="{ height: `${virtualListHeight}px`, display: 'flex', alignItems: 'center' }"
         />
         <a-empty v-else-if="list.length === 0" :style="{ height: `${virtualListHeight}px` }" />

--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -28,7 +28,7 @@
       </template>
       <template #scroll-loading>
         <a-spin
-          v-if="loading"
+          v-if="loading && !loadingMore"
           :style="{ height: `${virtualListHeight}px`, display: 'flex', alignItems: 'center' }"
         />
         <a-empty v-else-if="list.length === 0" :style="{ height: `${virtualListHeight}px` }" />

--- a/webui/src/views/banlist/components/banListItem.vue
+++ b/webui/src/views/banlist/components/banListItem.vue
@@ -4,6 +4,7 @@
     size="medium"
     class="banlist-item"
     :layout="(['inline-vertical', 'horizontal'] as const)[descriptionLayout]"
+    table-layout="fixed"
   >
     <template #title>
       <a-space fill style="display: flex; justify-content: space-between">
@@ -199,7 +200,7 @@ const handleUnban = async (address: string) => {
 }
 </script>
 
-<style scoped>
+<style lang="less" scoped>
 .red {
   color: red;
 }
@@ -221,5 +222,20 @@ a {
 .banlist-item:hover .hover-display-btn {
   transition: opacity 0.15s ease-in-out;
   opacity: 1;
+}
+</style>
+<style lang="less">
+.banlist-item {
+  div {
+    table {
+      tbody {
+        tr {
+          td.arco-descriptions-item-label {
+            width: 100px;
+          }
+        }
+      }
+    }
+  }
 }
 </style>


### PR DESCRIPTION
closed #601[WebUI] 表格内内容有时有偏移

修改table-layout为fixed，给td设置固定列宽，暂时无显示异常。后续有需要可修改为通过js动态计算最长的内容宽度

closed #530[WebUI] 刷新的时候banlist会跳变

经观察，第一个a-spin只是初始化数据时需要显示，后续loadingMore时不显示即可

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Improved loading indicator logic for better user experience in the ban list view.
	- Enhanced layout consistency of the ban list item descriptions with updated styling.

- **Bug Fixes**
	- Streamlined loading state management to prevent confusion during data loading operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->