### PR TITLE
QBittorrent进度验证使用种子总大小而不是选中大小

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/QBittorrentTorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/QBittorrentTorrent.java
@@ -187,7 +187,7 @@ public final class QBittorrentTorrent implements Torrent {
 
     @Override
     public long getSize() {
-        return size;
+        return totalSize;
     }
 
     @Override


### PR DESCRIPTION
使用选中的大小计算peer进度时，会导致算出的进度与peer汇报的进度不一致，导致误封

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved torrent size representation by updating the size retrieval method to return total size.
  
- **Bug Fixes**
	- Removed unnecessary commented-out fields for a cleaner and more efficient data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->