### PR TITLE
7.1.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.1.1</version>
+    <version>7.1.2</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/Main.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/Main.java
@@ -151,14 +151,15 @@ public class Main {
             appender.start(); // 启动 appender
         }
 
-        try{
+        try {
             var targetLevel = System.getProperty("pbh.log.level");
-            if(targetLevel != null) {
+            if (targetLevel != null) {
                 var rootLogger = LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
                 ch.qos.logback.classic.Logger logbackLogger = (ch.qos.logback.classic.Logger) rootLogger;
                 logbackLogger.setLevel(Level.toLevel(targetLevel));
             }
-        }catch (Throwable ignored){}
+        } catch (Throwable ignored) {
+        }
     }
 
     public static ReloadResult reloadModule() {
@@ -221,8 +222,14 @@ public class Main {
         logsDirectory = new File(dataDirectory, "logs");
         configDirectory = new File(dataDirectory, "config");
         pluginDirectory = new File(dataDirectory, "plugins");
-        libraryDirectory = new File(dataDirectory, "libraries");
         debugDirectory = new File(dataDirectory, "debug");
+        if (System.getProperty("pbh.configdir") != null) {
+            configDirectory = new File(System.getProperty("pbh.configdir"));
+        }
+        if (System.getProperty("pbh.logsdir") != null) {
+            logsDirectory = new File(System.getProperty("pbh.logsdir"));
+        }
+        // other directories aren't allowed to change by user to keep necessary structure
     }
 
     private static YamlConfiguration loadConfiguration(File file) {

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/QBittorrentTorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/QBittorrentTorrent.java
@@ -187,7 +187,7 @@ public final class QBittorrentTorrent implements Torrent {
 
     @Override
     public long getSize() {
-        return size;
+        return totalSize;
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
@@ -114,6 +114,7 @@ public class PBHBanController extends AbstractFeatureModule {
         var banResponseList = getServer().getBannedPeers()
                 .entrySet()
                 .stream()
+                .filter(b -> !b.getValue().isBanForDisconnect())
                 .map(entry -> new BanResponse(entry.getKey().getAddress().toString(), new BakedBanMetadata(locale, entry.getValue())))
                 .sorted((o1, o2) -> Long.compare(o2.getBanMetadata().getBanAt(), o1.getBanMetadata().getBanAt()));
         if (lastBanTime > 0) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
@@ -100,7 +100,8 @@ public class PBHBanController extends AbstractFeatureModule {
     private void handleBans(Context ctx) {
         long limit = Long.parseLong(Objects.requireNonNullElse(ctx.queryParam("limit"), "-1"));
         long lastBanTime = Long.parseLong(Objects.requireNonNullElse(ctx.queryParam("lastBanTime"), "-1"));
-        var banResponseList = getBanResponseStream(locale(ctx), lastBanTime, limit);
+        boolean ignoreBanForDisconnect = Boolean.parseBoolean(Objects.requireNonNullElse(ctx.queryParam("ignoreBanForDisconnect"), "true"));
+        var banResponseList = getBanResponseStream(locale(ctx), lastBanTime, limit, ignoreBanForDisconnect);
         ctx.json(new StdResp(true, null, banResponseList.toList()));
     }
 
@@ -110,11 +111,14 @@ public class PBHBanController extends AbstractFeatureModule {
     }
 
 
-    private @NotNull Stream<BanResponse> getBanResponseStream(String locale, long lastBanTime, long limit) {
+    private @NotNull Stream<BanResponse> getBanResponseStream(String locale, long lastBanTime, long limit, boolean ignoreBanForDisconnect) {
         var banResponseList = getServer().getBannedPeers()
                 .entrySet()
                 .stream()
-                .filter(b -> !b.getValue().isBanForDisconnect())
+                .filter(b -> {
+                    if(!ignoreBanForDisconnect) return true;
+                    return !b.getValue().isBanForDisconnect();
+                })
                 .map(entry -> new BanResponse(entry.getKey().getAddress().toString(), new BakedBanMetadata(locale, entry.getValue())))
                 .sorted((o1, o2) -> Long.compare(o2.getBanMetadata().getBanAt(), o1.getBanMetadata().getBanAt()));
         if (lastBanTime > 0) {

--- a/webui/src/components/autoUpdateBtn.vue
+++ b/webui/src/components/autoUpdateBtn.vue
@@ -1,17 +1,19 @@
 <template>
-  <a-popover>
+  <a-popover :popup-container="container">
     <a-button
       ref="autoUpdateBtn"
       class="auto-update-btn"
-      :class="{
-        loading: loadingStatus === 'loading' || loadingHolding,
-        'loading-holding': loadingStatus === 'idle' && loadingHolding
-      }"
       :type="autoUpdate.autoUpdate ? 'primary' : 'outline'"
       :shape="'circle'"
       @click="() => autoUpdate.refresh()"
     >
-      <icon-sync />
+      <icon-sync
+        id="spin"
+        :class="{
+          loading: loadingStatus === 'loading' || loadingHolding,
+          'loading-holding': loadingStatus === 'idle' && loadingHolding
+        }"
+      />
     </a-button>
     <template #title>
       <a-space>
@@ -27,17 +29,19 @@
 </template>
 
 <script setup lang="ts">
-import { useI18n } from 'vue-i18n'
-import { useAutoUpdate } from '@/stores/autoUpdate'
-import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useAutoUpdate } from '@/stores/autoUpdate';
+import { computed, onMounted, onUnmounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 const { t, d } = useI18n()
 const autoUpdate = useAutoUpdate()
 const autoUpdateBtn = ref()
 const loadingHolding = ref(false)
 
 let eventAbortController: AbortController
+const container = ref<HTMLElement>()
 
 onMounted(() => {
+  container.value = window.document.querySelector('body') as HTMLElement
   eventAbortController = new AbortController()
   autoUpdateBtn.value.$el.addEventListener(
     'animationstart',
@@ -71,10 +75,12 @@ const loadingStatus = computed(() => autoUpdate.status)
 .auto-update-btn,
 .auto-update-btn:hover {
   font-size: 16px;
-  &.loading {
-    animation: whirl 0.25s linear infinite;
-    &.loading-holding {
-      animation-iteration-count: 1;
+  #spin {
+    &.loading {
+      animation: whirl 0.25s linear infinite;
+      &.loading-holding {
+        animation-iteration-count: 1;
+      }
     }
   }
 }

--- a/webui/src/components/autoUpdateBtn.vue
+++ b/webui/src/components/autoUpdateBtn.vue
@@ -29,9 +29,9 @@
 </template>
 
 <script setup lang="ts">
-import { useAutoUpdate } from '@/stores/autoUpdate';
-import { computed, onMounted, onUnmounted, ref } from 'vue';
-import { useI18n } from 'vue-i18n';
+import { useAutoUpdate } from '@/stores/autoUpdate'
+import { computed, onMounted, onUnmounted, ref } from 'vue'
+import { useI18n } from 'vue-i18n'
 const { t, d } = useI18n()
 const autoUpdate = useAutoUpdate()
 const autoUpdateBtn = ref()

--- a/webui/src/views/charts/components/banTrends.vue
+++ b/webui/src/views/charts/components/banTrends.vue
@@ -110,6 +110,9 @@ const chartOptions = ref({
   tooltip: {
     trigger: 'axis'
   },
+  grid: {
+    left: '15%'
+  },
   series: [
     {
       data: [] as [Date, number][],

--- a/webui/src/views/charts/components/traffic.vue
+++ b/webui/src/views/charts/components/traffic.vue
@@ -140,6 +140,9 @@ const chartOptions = ref({
     min: 'dataMin',
     minInterval: 3600 * 24 * 1000
   },
+  grid: {
+    left: '15%'
+  },
   yAxis: {
     type: 'value',
     axisLabel: {

--- a/webui/src/views/dashboard/components/clientStatus.vue
+++ b/webui/src/views/dashboard/components/clientStatus.vue
@@ -24,7 +24,7 @@
       ]"
     >
       <!-- 骨架屏 -->
-      <a-col v-if="!data || data?.length === 0 || loading" :xs="24" :sm="12" :md="8" :lg="6">
+      <a-col v-if="!data || data?.length === 0 || firstLoading" :xs="24" :sm="12" :md="8" :lg="6">
         <a-card hoverable :header-style="{ height: 'auto' }">
           <template #title>
             <a-skeleton :animation="true">
@@ -82,12 +82,14 @@ import torrentList from './torrentList.vue'
 const { t } = useI18n()
 const endpointState = useEndpointStore()
 const data = ref<Downloader[]>()
-const { refresh, loading } = useRequest(
+const firstLoading = ref(true)
+const { refresh } = useRequest(
   getDownloaders,
   {
     cacheKey: () => `${endpointState.endpoint}-downloader`,
     onSuccess: (res) => {
       data.value = res.data
+      firstLoading.value = false
     }
   },
   [useAutoUpdatePlugin]

--- a/webui/src/views/data-view/ipList/index.vue
+++ b/webui/src/views/data-view/ipList/index.vue
@@ -13,7 +13,7 @@
         placeholder="192.168.1.1...."
         class="searchBox"
         :loading="loading"
-        @search="run"
+        @search="handleSearch"
       />
     </div>
     <div class="result-container center">
@@ -231,6 +231,11 @@ onMounted(() => {
     run(searchInput.value)
   }
 })
+const handleSearch = (value: string) => {
+  if (value) {
+    run(value)
+  }
+}
 </script>
 
 <style scoped>

--- a/webui/src/views/settings/components/info/locale/en-US.ts
+++ b/webui/src/views/settings/components/info/locale/en-US.ts
@@ -62,6 +62,7 @@ export default {
   'page.settings.tab.info.log.enableAutoRefresh': 'Auto Refresh',
   'page.settings.tab.info.log.hideBanWave': 'Hide check logs from Ban Wave',
   'page.settings.tab.info.log.showThread': 'Show Thread Name',
+  'page.settings.tab.info.log.autoScorll': 'Auto Scroll to Latest',
 
   'page.settings.tab.info.downloadHeap':
     'Start downloading heap dump file, this will take some time'

--- a/webui/src/views/settings/components/info/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/info/locale/zh-CN.ts
@@ -62,6 +62,7 @@ export default {
   'page.settings.tab.info.log.enableAutoRefresh': '自动刷新',
   'page.settings.tab.info.log.hideBanWave': '隐藏来自 Ban Wave 的检查日志',
   'page.settings.tab.info.log.showThread': '显示线程名',
+  'page.settings.tab.info.log.autoScorll': '自动滚动到最新',
 
   'page.settings.tab.info.downloadHeap': '开始下载堆转储文件，这需要一段时间'
 }


### PR DESCRIPTION
## 错误修复

* 修复进度反作弊检查在 qBittorrent 上对 “部分做种（Partial Seeds）” 的种子进行检查时未使用正确的总大小计算导致可能错误封禁 Peers 的问题 @maoruishan (first-time contributor)
* [WebUI] 修复WebUI的若干问题 @Ghost-chu  @Gaojianli 
  * 封禁名单现在忽略 “Peer 快速测试” 的封禁记录 
  * 修复 IP 列表不输入任何内容就点击搜索按钮引发错误的问题 
  * 修复 Dashboard 下载器刷新的时候出现骨架屏的问题
  * 修复流量统计图表 Y 轴刻度显示不全的问题 
  * 修复自动刷新图标进入刷新旋转动画时，会带飞悬浮信息框 
  * 新增一个控制按钮以控制新日志条目插入时页面跳动的问题 

## Docker

DockerHub: `ghostchu/peerbanhelper:v7.1.2`
阿里云国内镜像加速: `registry.cn-hangzhou.aliyuncs.com/ghostchu/peerbanhelper:v7.1.2`

注：有许多小伙伴询问是否可以使用 latest 标签，是可以使用的，只是如果你使用了镜像站，则 latest 标签可能不是最新的版本。 

---

# 7.1.1

## 错误修复

* 修复流量统计图表在 7.1.0 被破坏的问题 @Ghost-chu @paulzzh 
* 修复 httpd 可能在 IPDB 未下载完成之前就启动的问题 @Ghost-chu 
* 修复 IPDB 下载超时时有时不会切换备用源的问题 @Ghost-chu 
* 修复在非 zh-CN 的系统语言下，界面文本显示异常 @Ghost-chu  

---

# 7.1.0

> [!CAUTION]
> 本版包含重要安全修复，不管出于任何理由，您都应该更新到此修复版本。

## 关键安全性修复

* **【重要】修复了因错误使用 ORM 框架导致潜在 SQL 注入的问题** @Ghost-chu @paulzzh 
  * 恶意攻击者可通过在查询参数中插入 SQL 片段，执行任意 SQL 查询
* **【重要】修复了登录接口的 POST 登陆方式没有覆盖暴力破解防护的问题** @Ghost-chu 
  * 恶意攻击者可能对登录接口发起暴力破解穷举 WebUI Token 以获取 WebUI 访问权限，并间接获取连接的下载器的 WebUI 权限
* 添加了 `robots.txt` 并拒绝任何搜索引擎索引并避免在搜索引擎中暴露，但依然可能被 Censys 等网络空间测绘引擎发现，建议使用防火墙保护 @Ghost-chu 
  * 如果 PBH 部署在二级目录下，请自行管理 `robots.txt`
* 仅在登录阶段传递 Token，避免明文 WebUI Token 泄露

## 新功能

* 图表数据现在支持分下载器查看 @Gaojianli @Ghost-chu @paulzzh
* WebUI 现在支持自定义脚本编辑 @Gaojianli @Ghost-chu
  * 通过编程的方式构建自己的反吸血逻辑
  * 只有在局域网内直接访问 WebUI 才能添加和编辑脚本；通过互联网或者反向代理访问时，仅能查看脚本，不可添加修改编辑
  * **安全警告：自定义脚本可执行任意代码，请仅添加来自可信来源的脚本**
* **【重要】BTN 新增 “脚本规则” 规则类型，PeerBanHelper 现在可接收来自 BTN 服务器下发的脚本以提升基于云的检测防护能力，提高封禁的灵活和精确性** @Ghost-chu 
  * 需要手动在 “设置->基础设置->BTN” 开启 “启用脚本执行” 开关，此功能才会生效。请仅在可信 BTN 服务器上启用此功能。
* WebUI 现在可以进行堆内存转储 @Gaojianli 
* BTN 能力列表页面现在可查看云端规则数量和规则版本号 @Gaojianli @Ghost-chu 
* 其它用户体验改善

## 错误修复
* **【重要】优化了 IPMatcher 的CPU和内存占用，解决了困扰已久的规则过多时内存溢出的问题并大幅缩短了匹配 IP 时的 CPU 占用和匹配耗时，现在空载内存仅需要 92MB（GUI）** @Ghost-chu @paulzzh
  * 请注意：自 2024/11/06 后，旧版本（< 7.1.0） PBH 可能由于 IP 屏蔽列表的增长而耗尽内存，为了保证正常运行，请升级版本或者更改其最大堆内存
* 修复了当添加支持完整 PeerID 的下载器（如：BiglyBT/Azureus/Vuze、BitComet 或者 Deluge）时，查看 PeerID 饼图时完全不可读的问题 @Ghost-chu 
* Windows GUI 的打开 WebUI 按钮现在能够自动填充 token 登录 WebUI