### PR TITLE
v7.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.2.0</version>
+    <version>7.2.1</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -4,7 +4,6 @@ import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.alert.AlertManager;
 import com.ghostchu.peerbanhelper.database.Database;
 import com.ghostchu.peerbanhelper.database.dao.impl.BanListDao;
-import com.ghostchu.peerbanhelper.decentralized.IPFSBanListShare;
 import com.ghostchu.peerbanhelper.downloader.Downloader;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLastStatus;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLoginResult;
@@ -140,8 +139,8 @@ public class PeerBanHelperServer implements Reloadable {
     private BanListDao banListDao;
     @Autowired
     private Laboratory laboratory;
-    @Autowired
-    private IPFSBanListShare share;
+//    @Autowired
+//    private IPFSBanListShare share;
 
     public PeerBanHelperServer() {
         reloadConfig();
@@ -419,7 +418,7 @@ public class PeerBanHelperServer implements Reloadable {
         }
         try {
             int count = banListDao.saveBanList(BAN_LIST);
-            share.publishUpdate();
+            //share.publishUpdate();
             log.info(tlUI(Lang.SAVED_BANLIST, count));
         } catch (Exception e) {
             log.error(tlUI(Lang.SAVE_BANLIST_FAILED), e);

--- a/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
@@ -78,7 +78,7 @@ public class MainConfigUpdateScript {
 
     @UpdateScript(version = 24)
     public void decentralizedConfiguration() {
-        conf.set("decentralized.enabled", true);
+        conf.set("decentralized.enabled", false);
         conf.set("decentralized.kubo-rpc", "/ip4/127.0.0.1/tcp/5001");
         conf.set("decentralized.features.publish-banlist", 3600000);
     }

--- a/webui/src/components/alert.vue
+++ b/webui/src/components/alert.vue
@@ -110,6 +110,7 @@ import { Button, Message, Notification } from '@arco-design/web-vue'
 import { computed, h, ref } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useRequest } from 'vue-request'
+import Markdown from './markdown.vue'
 const { t, d } = useI18n()
 const visable = ref(false)
 useRequest(

--- a/webui/src/components/markdown.vue
+++ b/webui/src/components/markdown.vue
@@ -10,9 +10,9 @@
   <div v-else v-html="md.render(content)"></div>
 </template>
 <script lang="ts" setup>
-import { useDarkStore } from '@/stores/dark';
-import md from '@/utils/markdown';
-import { computed } from 'vue';
+import { useDarkStore } from '@/stores/dark'
+import md from '@/utils/markdown'
+import { computed } from 'vue'
 const darkStore = useDarkStore()
 
 const srcDoc = computed(() => {


### PR DESCRIPTION
v7.2.1 是 v7.2.0 的一个首日补丁，用于修复 v7.2.0 中已知的错误。

## 错误修复

* 修复 .deb 安装包安装时可能因为文件夹已经存在导致报错的问题 @Anuskuss
* 修复警报提示框中警报内容文本丢失的问题 @Gaojianli 
* 修复启动时 IPFS Share BanList 提示出错，导致 0 号测试组用户无法启动 PBH 的问题，我们暂时禁用了此功能，并将随下一个修复版本一同修复。 @Ghost-chu

## Docker

DockerHub: `ghostchu/peerbanhelper:v7.2.0`  
阿里云国内镜像加速: `registry.cn-hangzhou.aliyuncs.com/ghostchu/peerbanhelper:v7.2.0`

v7.2.0 更新日志请见：https://github.com/PBH-BTN/PeerBanHelper/releases/tag/v7.2.0

