### PR TITLE
Fixes #934 -修复"进度作弊检查“下面有个选项文字错误

### DIFF
--- a/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
+++ b/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
@@ -95,7 +95,7 @@
       ></a-input-number>
     </a-form-item>
     <a-form-item
-      :label="t('page.settings.tab.profile.module.progressCheatBlocker.banDuration')"
+      :label="t('page.settings.tab.profile.module.progressCheatBlocker.useGlobalBanTime')"
       field="model.ban_duration"
     >
       <a-space>

--- a/webui/src/views/settings/components/profile/locale/en-US.ts
+++ b/webui/src/views/settings/components/profile/locale/en-US.ts
@@ -71,7 +71,7 @@ export default {
   'page.settings.tab.profile.module.progressCheatBlocker.ipv6prefixlength': 'IPv6 prefix length',
   'page.settings.tab.profile.module.progressCheatBlocker.ipprefixLength.tips':
     'IPs from the same subnet are considered as the same user',
-  'page.settings.tab.profile.module.progressCheatBlocker.banDuration': 'Ban Duration',
+  'page.settings.tab.profile.module.progressCheatBlocker.useGlobalBanTime': 'Use global ban duration',
   'page.settings.tab.profile.module.progressCheatBlocker.enablePersist': 'Enable persist recording',
   'page.settings.tab.profile.module.progressCheatBlocker.enablePersist.tips':
     'Enable this feature may increase disk I/O and may affect performance, even may cause flash wear on embedded devices',

--- a/webui/src/views/settings/components/profile/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-CN.ts
@@ -65,7 +65,7 @@ export default {
   'page.settings.tab.profile.module.progressCheatBlocker.ipv6prefixlength': 'IPv6 前缀长度',
   'page.settings.tab.profile.module.progressCheatBlocker.ipprefixLength.tips':
     '来自同一子网的 IP 视为同一用户',
-  'page.settings.tab.profile.module.progressCheatBlocker.banDuration': '封禁持续时间',
+  'page.settings.tab.profile.module.progressCheatBlocker.useGlobalBanTime': '使用全局封禁时间',
   'page.settings.tab.profile.module.progressCheatBlocker.enablePersist': '启用持久化记录',
   'page.settings.tab.profile.module.progressCheatBlocker.enablePersist.tips':
     '启用此功能可能增加磁盘 I/O 并可能影响性能，嵌入式设备上甚至可能带来闪存磨损',


### PR DESCRIPTION
将 封禁持续时间 改为 使用全局封禁时间