### PR TITLE
fix outdated build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 echo "Setup webui files.."
-sh setup-webui.sh
+current_wd=$(pwd)
+static_dir="$(dirname $0)/src/main/resources/static"
+
+rm -rf ${static_dir} || echo ""
+cd ${current_wd}/webui
+pnpm install
+pnpm run build
+cd ${current_wd}
+cp -r webui/dist ${static_dir}
 
 echo "Prepare to build jar.."
 mvn -B clean package --file pom.xml


### PR DESCRIPTION
The `build.sh` script is outdated as `webui` is no longer a dedicated repository. This PR fixes the script in a way similar to what the original `setup-webui.sh` does, that after executing `build.sh` one can run `docker build . --file Dockerfile-Release` directly to build a local image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 优化构建流程，将网页界面的构建与静态资源管理整合到统一流程中，提高了依赖安装和资源更新的效率。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->