### PR TITLE
v7.4.3

### DIFF
--- a/.github/workflows/jvm-ci.yml
+++ b/.github/workflows/jvm-ci.yml
@@ -145,38 +145,38 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}-jvm-universal
         cache-from: type=gha
         cache-to: type=gha,mode=min
-  Build_Docker_Standalone:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - name: Set Up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set Up Buildx
-      uses: docker/setup-buildx-action@v3
-    - name: Extract metadata (tags, labels) for Docker
-      id: meta
-      uses: docker/metadata-action@v5.6.1
-      with:
-        images: ghostchu/peerbanhelper-snapshot
-        tags: |
-          type=ref,event=branch
-          type=ref,event=tag
-          type=ref,event=pr
-          type=semver,pattern={{version}}
-          type=semver,pattern={{major}}.{{minor}}
-          type=raw,ci-jvm-universal
-          type=raw,ci
-          type=sha
-    - name: Build and push Docker image
-      uses: docker/build-push-action@v6.13.0
-      with:
-        context: .
-        file: ./Dockerfile
-        push: false
-        platforms: |
-          linux/amd64
-          linux/arm64/v8
-        tags: ${{ steps.meta.outputs.tags }}
-        labels: ${{ steps.meta.outputs.labels }}-jvm-universal
-        cache-from: type=gha
-        cache-to: type=gha,mode=min
+#  Build_Docker_Standalone:
+#    runs-on: ubuntu-latest
+#    steps:
+#    - uses: actions/checkout@v4
+#    - name: Set Up QEMU
+#      uses: docker/setup-qemu-action@v3
+#    - name: Set Up Buildx
+#      uses: docker/setup-buildx-action@v3
+#    - name: Extract metadata (tags, labels) for Docker
+#      id: meta
+#      uses: docker/metadata-action@v5.6.1
+#      with:
+#        images: ghostchu/peerbanhelper-snapshot
+#        tags: |
+#          type=ref,event=branch
+#          type=ref,event=tag
+#          type=ref,event=pr
+#          type=semver,pattern={{version}}
+#          type=semver,pattern={{major}}.{{minor}}
+#          type=raw,ci-jvm-universal
+#          type=raw,ci
+#          type=sha
+#    - name: Build and push Docker image
+#      uses: docker/build-push-action@v6.13.0
+#      with:
+#        context: .
+#        file: ./Dockerfile
+#        push: false
+#        platforms: |
+#          linux/amd64
+#          linux/arm64/v8
+#        tags: ${{ steps.meta.outputs.tags }}
+#        labels: ${{ steps.meta.outputs.labels }}-jvm-universal
+#        cache-from: type=gha
+#        cache-to: type=gha,mode=min

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM --platform=$BUILDPLATFORM docker.io/maven:3.9.9-eclipse-temurin-21-alpine A
 COPY . /build
 WORKDIR /build
 RUN apk add --update npm curl git && \
-    curl -L https://unpkg.com/@pnpm/self-installer | node && \
+    wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash - && \
     cd webui && \
     pnpm i && \
     npm run build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,9 @@ FROM --platform=$BUILDPLATFORM docker.io/maven:3.9.9-eclipse-temurin-21-alpine A
 COPY . /build
 WORKDIR /build
 RUN apk add --update npm curl git && \
-    wget -qO- https://get.pnpm.io/install.sh | ENV="$HOME/.bashrc" SHELL="$(which bash)" bash - && \
+    wget -o pnpm-install.sh https://get.pnpm.io/install.sh && \
+    chmod +x pnpm-install.sh && \
+    ./pnpm-install.sh && \
     cd webui && \
     pnpm i && \
     npm run build && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,11 @@
-FROM --platform=$BUILDPLATFORM docker.io/maven:3.9.9-eclipse-temurin-21-alpine AS build
-
-COPY . /build
-WORKDIR /build
-RUN apk add --update npm curl git && \
-    wget -o pnpm-install.sh https://get.pnpm.io/install.sh && \
-    chmod +x pnpm-install.sh && \
-    ./pnpm-install.sh && \
-    cd webui && \
-    pnpm i && \
-    npm run build && \
-    cd .. && \
-    mv webui/dist src/main/resources/static && \
-    mvn -B clean package --file pom.xml -T 1.5C -P thin-sqlite-packaging
-
 FROM docker.io/bellsoft/liberica-runtime-container:jre-23-slim-musl
 LABEL maintainer="https://github.com/PBH-BTN/PeerBanHelper"
+COPY target/libraries /app/libraries
+COPY target/PeerBanHelper.jar /app/PeerBanHelper.jar
 USER 0
 EXPOSE 9898
 ENV TZ=UTC
 ENV JAVA_OPTS="-Dpbh.release=docker -Djava.awt.headless=true -Xmx512M -Xms16M -Xss512k -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ShrinkHeapInSteps"
 WORKDIR /app
 VOLUME /tmp
-COPY --from=build build/target/libraries /app/libraries
-COPY --from=build build/target/PeerBanHelper.jar /app/PeerBanHelper.jar
-ENV PATH="${JAVA_HOME}/bin:${PATH}"
 ENTRYPOINT ["sh", "-c", "${JAVA_HOME}/bin/java ${JAVA_OPTS} -jar PeerBanHelper.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.0</version>
+    <version>7.4.1</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.2</version>
+    <version>7.4.3</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.1</version>
+    <version>7.4.2</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -60,6 +60,7 @@ public final class BiglyBT extends AbstractDownloader {
     private final HttpClient httpClient;
     private final Config config;
     private final String connectorPayload;
+    private Semver semver = new Semver("0.0.0");
 
     public BiglyBT(String name, Config config, AlertManager alertManager) {
         super(name, alertManager);
@@ -120,7 +121,7 @@ public final class BiglyBT extends AbstractDownloader {
                 var version = metadataCallbackBean.getPluginVersion();
                 this.semver = new Semver(version);
                 // 检查是否大于等于 1.2.8
-                if (this.semver.isLowerThan("1.2.9")) {
+                if (this.semver.isLowerThan("1.3.0")) {
                     return new DownloaderLoginResult(DownloaderLoginResult.Status.REQUIRE_TAKE_ACTIONS, new TranslationComponent(Lang.DOWNLOADER_BIGLYBT_INCORRECT_ADAPTER_VERSION, "1.2.9"));
                 }
                 MutableRequest request = MutableRequest.POST(apiEndpoint + "/setconnector", HttpRequest.BodyPublishers.ofString(connectorPayload));


### PR DESCRIPTION
## 错误修复

* [上游] 更新 Methanol 请求库以修复在部分情况下请求下载器 API 会导致 PeerBanHelper 封禁线程挂起卡住触发 WatchDog 超时检测的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Chores**
  - 更新项目版本至 7.4.3，确保系统的稳定性与兼容性。
  - 升级 `gson` 依赖库版本至 2.12.1，提升功能和修复潜在问题。
  - 升级 `methanol` 依赖库版本至 1.8.1，提升功能和修复潜在问题。
  - 移除 Dockerfile 中的旧构建阶段，简化构建过程。
  - 删除 Java CI 工作流中的 `Build_Docker_Standalone` 作业，优化持续集成流程。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->