### PR TITLE
v7.4.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.8.1</version>
-                <configuration>
-                    <includeScope>runtime</includeScope>
-                </configuration>
                 <executions>
                     <execution>
                         <id>copy-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.6</version>
+    <version>7.4.7</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>


### PR DESCRIPTION
## 错误修复

1. 修复部分 docker 部署的用户在 7.4.5 之后的版本无法启动的问题


## Docker

DockerHub: `ghostchu/peerbanhelper:v7.4.7`  
阿里云国内镜像加速: `registry.cn-hangzhou.aliyuncs.com/ghostchu/peerbanhelper:v7.4.7`

---

[部署教程](https://docs.pbh-btn.com/docs/category/%E5%AE%89%E8%A3%85%E9%83%A8%E7%BD%B2) | [常见问题](https://docs.pbh-btn.com/docs/faq) | [如何设置下载器](https://docs.pbh-btn.com/docs/category/%E4%B8%8B%E8%BD%BD%E5%99%A8%E9%85%8D%E7%BD%AE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- 更新了项目版本，确保使用最新构建环境。
	- 优化了依赖管理设置，调整了依赖复制行为，以提高整体构建流程的稳定性和灵活性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->