### PR TITLE
v7.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.11</version>
+    <version>7.4.12</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelperServer.java
@@ -164,7 +164,6 @@ public class PeerBanHelperServer implements Reloadable {
         reloadConfig();
         loadDownloaders();
         resetKnownDownloaders();
-        loadBanListToMemory();
         registerTimer();
         unbanWhitelistedPeers();
         return Reloadable.super.reloadModule();

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/TrafficJournalDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/TrafficJournalDao.java
@@ -97,7 +97,9 @@ public final class TrafficJournalDao extends AbstractPBHDao<TrafficJournalEntity
                             Long.parseLong(args[3]),
                             Long.parseLong(args[4])
                     )
-            ).map(data -> new TrafficDataDto(data.getTimestamp(), data.getDataOverallUploaded(), data.getDataOverallDownloaded())).toList();
+            ).map(data -> new TrafficDataDto(data.getTimestamp(),
+                    data.getDataOverallUploadedAtStart() - data.getDataOverallUploaded(),
+                    data.getDataOverallDownloadedAtStart() - data.getDataOverallDownloaded())).toList();
         }
     }
 
@@ -116,7 +118,9 @@ public final class TrafficJournalDao extends AbstractPBHDao<TrafficJournalEntity
                         e.getDataOverallUploaded(),
                         e.getDataOverallDownloadedAtStart(),
                         e.getDataOverallDownloaded()))
-                .map(data -> new TrafficDataDto(data.getTimestamp(), data.getDataOverallUploaded(), data.getDataOverallDownloaded()))
+                .map(data -> new TrafficDataDto(data.getTimestamp(),
+                        data.getDataOverallUploadedAtStart() - data.getDataOverallUploaded(),
+                        data.getDataOverallDownloadedAtStart() - data.getDataOverallDownloaded()))
                 .toList();
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/TrafficJournalDao.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/dao/impl/TrafficJournalDao.java
@@ -98,8 +98,8 @@ public final class TrafficJournalDao extends AbstractPBHDao<TrafficJournalEntity
                             Long.parseLong(args[4])
                     )
             ).map(data -> new TrafficDataDto(data.getTimestamp(),
-                    data.getDataOverallUploadedAtStart() - data.getDataOverallUploaded(),
-                    data.getDataOverallDownloadedAtStart() - data.getDataOverallDownloaded())).toList();
+                    data.getDataOverallUploaded() - data.getDataOverallUploadedAtStart(),
+                    data.getDataOverallDownloaded() - data.getDataOverallDownloadedAtStart())).toList();
         }
     }
 
@@ -119,8 +119,8 @@ public final class TrafficJournalDao extends AbstractPBHDao<TrafficJournalEntity
                         e.getDataOverallDownloadedAtStart(),
                         e.getDataOverallDownloaded()))
                 .map(data -> new TrafficDataDto(data.getTimestamp(),
-                        data.getDataOverallUploadedAtStart() - data.getDataOverallUploaded(),
-                        data.getDataOverallDownloadedAtStart() - data.getDataOverallDownloaded()))
+                        data.getDataOverallUploaded() - data.getDataOverallUploadedAtStart(),
+                        data.getDataOverallDownloaded() - data.getDataOverallDownloadedAtStart()))
                 .toList();
     }
 


### PR DESCRIPTION
## 错误修复

1. 修复 SPK 安装包在新版 DSM 的 Container Manager 上无法安装，容器状态无法正常获取的问题 @tbc0309 (首次贡献)
2. 修复存在已久的 HTTP Client 内存泄漏问题，在长时间运行、添加多个下载器、高检查频率的情况下可能导致 PeerBanHelper 的 RAM 使用维持在一个异常的高水平 mizosoft/methanol#121 @Ghost-chu 
3. 修复存在已久的流量统计不准确的问题。当用户超过一天未运行 PeerBanHelper 后，再次开启新的一天时，当天流量被错误地记录为当前下载器的传输量总和。现已通过重写算法修复，这应该也一同修复了因错误统计导致 “流量告警” 功能无法可靠运行的问题 @Ghost-chu 
  3.1 当更新到此版本时，过往的流量数据将被清除，因为过往的错误数据结构设计使得可靠和准确地升级历史数据变的不可能
4. 修复重载配置文件时，可能导致封禁列表中的封禁地址丢失 @Ghost-chu 

## 删除的功能

1. “使用已知数据填充流量统计缺失的数据” 实验室测试功能已下线，因为新的算法修复了统计数据的异常问题，该实验已完成了其历史使命 @Ghost-chu

## Docker

DockerHub: `ghostchu/peerbanhelper:v7.4.12`  
阿里云国内镜像加速: `registry.cn-hangzhou.aliyuncs.com/ghostchu/peerbanhelper:v7.4.12`

---

[部署教程](https://docs.pbh-btn.com/docs/category/%E5%AE%89%E8%A3%85%E9%83%A8%E7%BD%B2) | [常见问题](https://docs.pbh-btn.com/docs/faq) | [如何设置下载器](https://docs.pbh-btn.com/docs/category/%E4%B8%8B%E8%BD%BD%E5%99%A8%E9%85%8D%E7%BD%AE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 项目版本更新至 7.4.12。

- **Refactor**
  - 模块重载时不再自动刷新禁用名单，可能需要手动更新相关信息。
  - 优化了流量统计计算逻辑，现在采用初始数值与当前数值的差值，提供更精确的数据反馈。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->