### PR TITLE
[FreeBSD] Updaate rc.d to support multiple installed java

### DIFF
--- a/pkg/pkg/work-dir/usr/local/etc/rc.d/peerbanhelper
+++ b/pkg/pkg/work-dir/usr/local/etc/rc.d/peerbanhelper
@@ -9,6 +9,7 @@
 name="peerbanhelper"
 rcvar=peerbanhelper_enable
 
+export JAVA_VERSION=21
 
 : ${peerbanhelper_enable:=NO}
 : ${peerbanhelper_user:="root"}

--- a/pkg/pkg/work-dir/usr/local/etc/rc.d/peerbanhelper
+++ b/pkg/pkg/work-dir/usr/local/etc/rc.d/peerbanhelper
@@ -9,7 +9,7 @@
 name="peerbanhelper"
 rcvar=peerbanhelper_enable
 
-export JAVA_VERSION=21
+export JAVA_VERSION=${JAVA_VERSION:-21}
 
 : ${peerbanhelper_enable:=NO}
 : ${peerbanhelper_user:="root"}


### PR DESCRIPTION
In FreeBSD, system won't select java version 21 if multiple javas are installed.
In my case, I have both 17 and 21 installed.

``` bash
/usr/local/openjdk17
/usr/local/openjdk21
```
Direct execute `java` will invoke version 17, which will break peerbanhelper run.

``` bash
$ java -version
openjdk version "17.0.14" 2025-01-21
OpenJDK Runtime Environment (build 17.0.14+7-1)
OpenJDK 64-Bit Server VM (build 17.0.14+7-1, mixed mode, sharing)
```

However, adding an environment can help selecting the java version

``` bash
$ JAVA_VERSION=21 java --version
openjdk 21.0.6 2025-01-21
OpenJDK Runtime Environment (build 21.0.6+7-1)
OpenJDK 64-Bit Server VM (build 21.0.6+7-1, mixed mode, sharing)

```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 脚本现在会导出环境变量 `JAVA_VERSION=21`，确保默认使用该版本。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->