### PR TITLE
7.4.15

### DIFF
--- a/.github/workflows/jvm-ci-pr.yml
+++ b/.github/workflows/jvm-ci-pr.yml
@@ -28,10 +28,3 @@ jobs:
           cache-dependency-path: '**/pom.xml'
       - name: Build with Maven
         run: mvn -B clean package --file pom.xml -P thin-sqlite-packaging
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: maven-dist
-          path: |
-            target/*.jar
-            target/media/*.exe

--- a/.github/workflows/jvm-ci-pr.yml
+++ b/.github/workflows/jvm-ci-pr.yml
@@ -5,7 +5,8 @@ name: Java CI (pull_request)
 
 on:
   pull_request:
-    branches: [ "master", "release" ]
+    types:
+      - opened
   workflow_dispatch:
 jobs:
   WebUI:

--- a/.github/workflows/jvm-ci-pr.yml
+++ b/.github/workflows/jvm-ci-pr.yml
@@ -5,8 +5,6 @@ name: Java CI (pull_request)
 
 on:
   pull_request:
-    types:
-      - opened
   workflow_dispatch:
 jobs:
   WebUI:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>7.4.14</version>
+    <version>7.4.15</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -341,9 +341,8 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
                 double lastRecord = clientTask.getLastReportProgress();
                 double rewind = lastRecord - peer.getProgress();
                 // isUploadingToPeer 是为了确认下载器再给对方上传数据，因为对方使用 “超级做种” 时汇报的进度可能并不准确
-                boolean ban = rewind > rewindMaximumDifference && isUploadingToPeer(peer);
-                if (ban) {
-                    if (banPeerIfConditionReached(clientTask)) {
+                if (rewind > rewindMaximumDifference && isUploadingToPeer(peer)) { // 进度回退且在上传
+                    if (banPeerIfConditionReached(clientTask) || peer.getProgress() > 0.0d) { // 满足等待时间或者 Peer 进度大于 0% (Peer 已更新 BIT_FIELD)
                         clientTask.setRewindCounter(clientTask.getRewindCounter() + 1);
                         clientTask.setBanDelayWindowEndAt(0L);
                         progressRecorder.invalidate(client); // 封禁时，移除缓存

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -343,11 +343,20 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
                 // isUploadingToPeer 是为了确认下载器再给对方上传数据，因为对方使用 “超级做种” 时汇报的进度可能并不准确
                 boolean ban = rewind > rewindMaximumDifference && isUploadingToPeer(peer);
                 if (ban) {
-                    clientTask.setRewindCounter(clientTask.getRewindCounter() + 1);
-                    clientTask.setBanDelayWindowEndAt(0L);
-                    progressRecorder.invalidate(client); // 封禁时，移除缓存
+                    if (banPeerIfConditionReached(clientTask)) {
+                        clientTask.setRewindCounter(clientTask.getRewindCounter() + 1);
+                        clientTask.setBanDelayWindowEndAt(0L);
+                        progressRecorder.invalidate(client); // 封禁时，移除缓存
+                        return new CheckResult(getClass(), PeerAction.BAN, 0, new TranslationComponent(Lang.PCB_RULE_PROGRESS_REWIND),
+                                new TranslationComponent(Lang.MODULE_PCB_PEER_BAN_REWIND,
+                                        percent(clientProgress),
+                                        percent(actualProgress),
+                                        percent(lastRecord),
+                                        percent(rewind),
+                                        percent(rewindMaximumDifference)));
+                    }
                 }
-                return new CheckResult(getClass(), ban ? PeerAction.BAN : PeerAction.NO_ACTION, 0, new TranslationComponent(Lang.PCB_RULE_PROGRESS_REWIND),
+                return new CheckResult(getClass(), PeerAction.NO_ACTION, 0, new TranslationComponent(Lang.PCB_RULE_PROGRESS_REWIND),
                         new TranslationComponent(Lang.MODULE_PCB_PEER_BAN_REWIND,
                                 percent(clientProgress),
                                 percent(actualProgress),


### PR DESCRIPTION
## 错误修复

1. 修复在恶劣网络环境下，由于 BIT_FIELD 消息传输延迟（或者丢包）导致 Peer 无法及时与 BT 下载器同步进度导致进度显示 0% 而被错误判定为进度回退的问题。现在进度回退封禁跟随封禁前等待时间设定以给予 Peer 重传 BIT_FIELD 消息的机会 @jintao-luo @Ghost-chu 

## Docker

DockerHub: `ghostchu/peerbanhelper:v7.4.15`  
阿里云国内镜像加速: `registry.cn-hangzhou.aliyuncs.com/ghostchu/peerbanhelper:v7.4.15`

---

[部署教程](https://docs.pbh-btn.com/docs/category/%E5%AE%89%E8%A3%85%E9%83%A8%E7%BD%B2) | [常见问题](https://docs.pbh-btn.com/docs/faq) | [如何设置下载器](https://docs.pbh-btn.com/docs/category/%E4%B8%8B%E8%BD%BD%E5%99%A8%E9%85%8D%E7%BD%AE)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 无新增功能。

- **修复**
  - 优化了因进度回退导致的对等端封禁逻辑，进一步细化了封禁条件，提升了判断准确性。

- **杂项**
  - 项目版本号从 7.4.14 升级至 7.4.15。
  - 持续集成流程调整：现已支持任意分支的拉取请求，并移除了构建产物上传步骤。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->