### PR TITLE
拦截 Transmission 4.0.6 (IPV6 42:aff:fe) 多拨伪装吸血

### DIFF
--- a/src/main/resources/scripts/42-aff-fe-tr4060.av
+++ b/src/main/resources/scripts/42-aff-fe-tr4060.av
@@ -1,4 +1,9 @@
-```
+## @NAME 拦截 Transmission 4.0.6 (IPV6 42:aff:fe) 多拨伪装吸血
+## @AUTHOR PBH-BTN Community
+## @CACHEABLE true
+## @VERSION 1.0
+## @THREADSAFE true
+
 if(isBlank(peer.clientName)) {
     return false; ## 下载器必须提供 ClientName
 }
@@ -15,4 +20,3 @@ if(string.contains(strIp, "42:aff:fe")){
 }
 
 return false;
-```

--- a/src/main/resources/scripts/42-aff-fe-tr4060.av
+++ b/src/main/resources/scripts/42-aff-fe-tr4060.av
@@ -1,0 +1,18 @@
+```
+if(isBlank(peer.clientName)) {
+    return false; ## 下载器必须提供 ClientName
+}
+
+ipAddress = peer.peerAddress.address;
+strIp = toString(ipAddress);
+
+if(!string.contains(peer.clientName, 'Transmission 4.0.6')){
+    return false; ## 不管非 Transmission 4.0.6 的
+}
+
+if(string.contains(strIp, "42:aff:fe")){
+    return "Transmission 4.0.6 (IPV6 2408:822e:xxxx:xxxx:42:aff:fexx:50b) 多拨伪装吸血";
+}
+
+return false;
+```

--- a/src/main/resources/scripts/42-aff-fe-tr4060.av
+++ b/src/main/resources/scripts/42-aff-fe-tr4060.av
@@ -1,4 +1,4 @@
-## @NAME 拦截 Transmission 4.0.6 (IPV6 42:aff:fe) 多拨伪装吸血
+## @NAME IPV6 42:aff:fe Transmission 4.0.6 刷流
 ## @AUTHOR PBH-BTN Community
 ## @CACHEABLE true
 ## @VERSION 1.0
@@ -16,7 +16,7 @@ if(!string.contains(peer.clientName, 'Transmission 4.0.6')){
 }
 
 if(string.contains(strIp, "42:aff:fe")){
-    return "Transmission 4.0.6 (IPV6 2408:822e:xxxx:xxxx:42:aff:fexx:50b) 多拨伪装吸血";
+    return "Transmission 4.0.6 (IPV6 42:aff:fe) 多拨伪装吸血";
 }
 
 return false;


### PR DESCRIPTION
拦截 Transmission 4.0.6 (IPV6 42:aff:fe) 多拨伪装吸血

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增客户端识别与过滤脚本，可根据客户端名称和IP地址模式自动筛选特定的Transmission 4.0.6客户端，并识别特定IPv6地址特征的用户。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->