### PR TITLE
fix: 搜索封禁名单时获取到的搜索关键词被URL编码

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
@@ -28,6 +28,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
+import java.net.URLDecoder;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Stream;
@@ -140,7 +141,7 @@ public final class PBHBanController extends AbstractFeatureModule {
         boolean ignoreBanForDisconnect =
                 Boolean.parseBoolean(Objects.requireNonNullElse(ctx.queryParam("ignoreBanForDisconnect"), "true"));
         String search = ctx.queryParam("search");
-
+        if (search!=null) search = URLDecoder.decode(search);
         if (hasPageParam) {
             /* ---------------- Pagination path ---------------- */
             Pageable pageable = new Pageable(ctx); // reads page & pageSize

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHBanController.java
@@ -29,6 +29,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Stream;
@@ -141,7 +142,7 @@ public final class PBHBanController extends AbstractFeatureModule {
         boolean ignoreBanForDisconnect =
                 Boolean.parseBoolean(Objects.requireNonNullElse(ctx.queryParam("ignoreBanForDisconnect"), "true"));
         String search = ctx.queryParam("search");
-        if (search!=null) search = URLDecoder.decode(search);
+        if (search != null) search = URLDecoder.decode(search, StandardCharsets.UTF_8);
         if (hasPageParam) {
             /* ---------------- Pagination path ---------------- */
             Pageable pageable = new Pageable(ctx); // reads page & pageSize


### PR DESCRIPTION
引发该issus https://github.com/PBH-BTN/PeerBanHelper/issues/1178 的原因是后端获取到的搜索参数被URL编码了，如输入`240e:390`，后端获取到的是编码后的`240e%3A390`

<img width="2472" height="112" alt="CleanShot 2025-08-04 at 15 41 02@2x" src="https://github.com/user-attachments/assets/b198136f-bda0-4189-a7c5-85d28b9008ff" />


现已修复

<img width="2930" height="860" alt="CleanShot 2025-08-04 at 15 41 20@2x" src="https://github.com/user-attachments/assets/6527a0e6-b551-48ec-86ba-fb96559fbf47" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复问题**
  * 修复了搜索功能中对查询参数的解码处理，提升了搜索的准确性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->