### PR TITLE
新增 qb4670 客户端 8088/8089 端口检测av脚本

### DIFF
--- a/src/main/resources/scripts/ban-qB4670-portcheck.av
+++ b/src/main/resources/scripts/ban-qB4670-portcheck.av
@@ -1,0 +1,82 @@
+## @NAME qb4670 8088 8089端口检测封禁
+## @AUTHOR nlsdt
+## @CACHEABLE true
+## @VERSION 1.1
+## @THREADSAFE true
+
+## BSD Zero Clause License
+##
+## Copyright (C) 2025 by nlsdt <xsfx0313@proton.me>
+##
+## Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted.
+##
+## THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+## MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+## RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+## CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+##
+## SPDX-License-Identifier: 0BSD
+
+## 常量参数
+let _TIMEOUT = 2000; ## 超时时间 ，单位为毫秒
+let _PORT_1  = 8088; ## 检查端口1
+let _PORT_2  = 8089; ## 检查端口2
+
+## 基础检查
+
+    if(isBlank(peer.clientName) || isBlank(peer.peerId)) {
+        return false; ## 二元组任意为空都不能继续检查，需要下载器支持
+    }
+    if (!string.startsWith(peer.peerId, "-qB4670-")) {
+        return false; ## 必须是 qB4670
+    }
+
+
+## 端口检查
+    ## 获取IP地址
+    let ipAddress = peer.peerAddress.address; ## 获取peerip
+    let strIp = toString(ipAddress);  ## 转化为字符串
+
+    ## TODO:将 ::ffff: v6 转换为 v4，目前为直接抛弃所有v6
+    if (string.startsWith(strIp, "::ffff:")) {
+        strIp = string.substring(strIp, 7); ##提取 v4
+    } elsif (string.contains(strIp, ":")) {
+        return false; ##纯 v6 拒绝
+    }
+    ## 导入 java 静态方法
+    use java.net.Socket;
+    use java.net.InetSocketAddress;
+    use java.io.IOException;
+
+    ## checkport主函数
+    let check_port = lambda(ip, port, timeout_ms) ->
+        let timeout = timeout_ms != nil ? timeout_ms : 2000;
+        let socket = nil;
+        try {
+            socket = new Socket();
+            let address = new InetSocketAddress(ip, port);
+            connect(socket, address, timeout);
+            return true;
+            } catch (IOException e) {
+                return false;
+            } finally {
+                if socket != nil {
+                try {
+                    close(socket);
+                } catch(IOException e) {
+                ## 忽略关闭时的异常
+                }
+            }
+        }
+    end;
+
+## 端口封禁检测
+let port1_open = check_port(strIp, _PORT_1, _TIMEOUT);
+let port2_open = check_port(strIp, _PORT_2, _TIMEOUT);
+if (port1_open && port2_open) {
+    ##let result = "qb4670 " + _PORT_1 + "/" + _PORT_2 " 端口开放"
+    ##return result;
+    ## TODO: 端口字符串拼接
+    return "qB4670 8088/8089 端口开放";
+}
+return false;


### PR DESCRIPTION
大佬们好，

感谢您在百忙之中审查此pr

该规则脚本 (`qb4670-port-check.av`) 的核心逻辑如下：

1.  客户端识别: 首先通过 `peer.peerId` 精准筛选出 `-qB4670-` 客户端，避免对其他客户端进行不必要的端口扫描，性能开销极小。
2.  IP 地址处理: 脚本能够正确处理 IPv4 映射的 IPv6 地址 (`::ffff:`)，并提取其中的 IPv4 地址用于检测。目前会暂时忽略纯 IPv6 用户以避免潜在的复杂性。(似乎也没有纯v6的样本出现)
3.  端口检测: 使用 Java 的 `Socket` 连接，通过设置 `2000ms` 的超时时间，以非阻塞的方式检测目标 Peer 的 `8088` 和 `8089` 端口是否可达。
4.  触发条件: 当且仅当两个端口均开放时，会返回成功信息 `"qB4670 8088/8089 端口开放"`，从而触发 PeerBanHelper 的封禁或标记逻辑。

这个规则我自己已经在本地测试通过，可以有效识别出目标客户端。

麻烦各位帮忙 review，感谢！

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 新增 qB4670 端口连通性检测：从对端地址解析 IP（兼容 IPv4-mapped），在 2 秒超时内分别检测 8088 与 8089；两端口均可达时返回“qB4670 8088/8089 端口开放”。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->