### PR TITLE
feat(banlist): add confirmation for unban all button

### DIFF
--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -8,14 +8,20 @@
           once
           :async-fn="() => handleUnban('*')"
         >
-          <a-button
-            type="secondary"
-            :disabled="(list?.length ?? 0) === 0"
-            :loading="unbaning"
-            @click="unban"
+          <a-popconfirm
+            :content="t('page.banlist.banlist.unbanAllConfirm')"
+            type="warning"
+            position="bottom"
+            @ok="unban"
           >
-            {{ t('page.banlist.banlist.listItem.unbanall') }}
-          </a-button>
+            <a-button
+              type="secondary"
+              :disabled="(list?.length ?? 0) === 0"
+              :loading="unbaning"
+            >
+              {{ t('page.banlist.banlist.listItem.unbanall') }}
+            </a-button>
+          </a-popconfirm>
         </AsyncMethod>
         <a-input-search
           :style="{ width: '250px' }"

--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -4,12 +4,12 @@
       <a-typography-text>{{ t('page.banlist.banlist.description') }}</a-typography-text>
       <a-space class="list-header-right-group" wrap>
         <AsyncMethod
-          v-slot="{ run: unban, loading: unbaning }"
+          v-slot="{ run: unban, loading: unbanning }"
           once
           :async-fn="() => handleUnban('*')"
         >
           <a-popconfirm
-            :content="t('page.banlist.banlist.unbanAllConfirm')"
+            :content="t('page.banlist.banlist.listItem.unbanall.confirm')"
             type="warning"
             position="bottom"
             @ok="unban"
@@ -17,7 +17,7 @@
             <a-button
               type="secondary"
               :disabled="(list?.length ?? 0) === 0"
-              :loading="unbaning"
+              :loading="unbanning"
             >
               {{ t('page.banlist.banlist.listItem.unbanall') }}
             </a-button>

--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -12,7 +12,7 @@
             :content="t('page.banlist.banlist.listItem.unbanall.confirm')"
             type="warning"
             position="bottom"
-            @ok="unban"
+            :before-ok="unban"
           >
             <a-button
               type="secondary"

--- a/webui/src/views/banlist/components/banList.vue
+++ b/webui/src/views/banlist/components/banList.vue
@@ -14,11 +14,7 @@
             position="bottom"
             :before-ok="unban"
           >
-            <a-button
-              type="secondary"
-              :disabled="(list?.length ?? 0) === 0"
-              :loading="unbanning"
-            >
+            <a-button type="secondary" :disabled="(list?.length ?? 0) === 0" :loading="unbanning">
               {{ t('page.banlist.banlist.listItem.unbanall') }}
             </a-button>
           </a-popconfirm>

--- a/webui/src/views/banlist/locale/en-US.ts
+++ b/webui/src/views/banlist/locale/en-US.ts
@@ -18,7 +18,7 @@ export default {
   'page.banlist.banlist.bottomReached': 'No more data!',
   'page.banlist.banlist.listItem.unban': 'Unban',
   'page.banlist.banlist.listItem.unbanall': 'Unban all',
-  'page.banlist.banlist.unbanAllConfirm': 'Are you sure you want to unban all IP addresses? This action cannot be undone',
+  'page.banlist.banlist.listItem.unbanall.confirm': 'Are you sure to unban all IP address(es)? This action cannot be undone',
   'page.banlist.banlist.listItem.unbanUnexcepted': 'No IP address(s) unbanned',
   'page.banlist.banlist.listItem.unbanSuccess': 'Unbanned {count} IP address(es)',
   'page.banlist.banlist.listItem.threatAnalyse': 'Threat Analyse'

--- a/webui/src/views/banlist/locale/en-US.ts
+++ b/webui/src/views/banlist/locale/en-US.ts
@@ -18,7 +18,8 @@ export default {
   'page.banlist.banlist.bottomReached': 'No more data!',
   'page.banlist.banlist.listItem.unban': 'Unban',
   'page.banlist.banlist.listItem.unbanall': 'Unban all',
-  'page.banlist.banlist.listItem.unbanall.confirm': 'Are you sure to unban all IP address(es)? This action cannot be undone',
+  'page.banlist.banlist.listItem.unbanall.confirm':
+    'Are you sure to unban all IP address(es)? This action cannot be undone',
   'page.banlist.banlist.listItem.unbanUnexcepted': 'No IP address(s) unbanned',
   'page.banlist.banlist.listItem.unbanSuccess': 'Unbanned {count} IP address(es)',
   'page.banlist.banlist.listItem.threatAnalyse': 'Threat Analyse'

--- a/webui/src/views/banlist/locale/en-US.ts
+++ b/webui/src/views/banlist/locale/en-US.ts
@@ -18,7 +18,8 @@ export default {
   'page.banlist.banlist.bottomReached': 'No more data!',
   'page.banlist.banlist.listItem.unban': 'Unban',
   'page.banlist.banlist.listItem.unbanall': 'Unban all',
+  'page.banlist.banlist.unbanAllConfirm': 'Are you sure you want to unban all IP addresses? This action cannot be undone',
   'page.banlist.banlist.listItem.unbanUnexcepted': 'No IP address(s) unbanned',
-  'page.banlist.banlist.listItem.unbanSuccess': 'Unbanned {count} IP address',
+  'page.banlist.banlist.listItem.unbanSuccess': 'Unbanned {count} IP address(es)',
   'page.banlist.banlist.listItem.threatAnalyse': 'Threat Analyse'
 }

--- a/webui/src/views/banlist/locale/zh-CN.ts
+++ b/webui/src/views/banlist/locale/zh-CN.ts
@@ -18,6 +18,7 @@ export default {
   'page.banlist.banlist.bottomReached': '已经到底啦！',
   'page.banlist.banlist.listItem.unban': '解除封禁',
   'page.banlist.banlist.listItem.unbanall': '解封全部',
+  'page.banlist.banlist.unbanAllConfirm': '您确定要解封所有 IP 地址吗？此操作无法撤销',
   'page.banlist.banlist.listItem.unbanUnexcepted': '没有 IP 地址被成功解除封禁',
   'page.banlist.banlist.listItem.unbanSuccess': '成功解封 {count} 个 IP 地址',
   'page.banlist.banlist.listItem.threatAnalyse': '威胁分析'

--- a/webui/src/views/banlist/locale/zh-CN.ts
+++ b/webui/src/views/banlist/locale/zh-CN.ts
@@ -18,7 +18,7 @@ export default {
   'page.banlist.banlist.bottomReached': '已经到底啦！',
   'page.banlist.banlist.listItem.unban': '解除封禁',
   'page.banlist.banlist.listItem.unbanall': '解封全部',
-  'page.banlist.banlist.unbanAllConfirm': '您确定要解封所有 IP 地址吗？此操作无法撤销',
+  'page.banlist.banlist.listItem.unbanall.confirm': '您确定要解封所有 IP 地址吗？此操作无法撤销',
   'page.banlist.banlist.listItem.unbanUnexcepted': '没有 IP 地址被成功解除封禁',
   'page.banlist.banlist.listItem.unbanSuccess': '成功解封 {count} 个 IP 地址',
   'page.banlist.banlist.listItem.threatAnalyse': '威胁分析'

--- a/webui/src/views/banlist/locale/zh-TW.ts
+++ b/webui/src/views/banlist/locale/zh-TW.ts
@@ -18,6 +18,7 @@ export default {
   'page.banlist.banlist.bottomReached': '已經到底啦！',
   'page.banlist.banlist.listItem.unban': '解除封禁',
   'page.banlist.banlist.listItem.unbanall': '解封全部',
+  'page.banlist.banlist.unbanAllConfirm': '您確定要解封所有 IP 位址嗎？此操作無法撤銷',
   'page.banlist.banlist.listItem.unbanUnexcepted': '沒有 IP 位址被成功解除封禁',
   'page.banlist.banlist.listItem.unbanSuccess': '成功解封 {count} 個 IP 位址',
   'page.banlist.banlist.listItem.threatAnalyse': '威脅分析'

--- a/webui/src/views/banlist/locale/zh-TW.ts
+++ b/webui/src/views/banlist/locale/zh-TW.ts
@@ -18,7 +18,7 @@ export default {
   'page.banlist.banlist.bottomReached': '已經到底啦！',
   'page.banlist.banlist.listItem.unban': '解除封禁',
   'page.banlist.banlist.listItem.unbanall': '解封全部',
-  'page.banlist.banlist.unbanAllConfirm': '您確定要解封所有 IP 位址嗎？此操作無法撤銷',
+  'page.banlist.banlist.listItem.unbanall.confirm': '您確定要解封所有 IP 位址嗎？此操作無法撤銷',
   'page.banlist.banlist.listItem.unbanUnexcepted': '沒有 IP 位址被成功解除封禁',
   'page.banlist.banlist.listItem.unbanSuccess': '成功解封 {count} 個 IP 位址',
   'page.banlist.banlist.listItem.threatAnalyse': '威脅分析'


### PR DESCRIPTION
为“全部解封”按钮增加了气泡确认框，以防止用户误触（关于我想点搜索框一下手滑解封了有500多条的惨痛教训）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新功能
  - 为“一键解除封禁”按钮添加确认弹窗，需确认后才执行原有解除操作，减少误点风险并显示加载状态。
- 本地化
  - 新增“解除全部封禁”确认提示的中、英、繁体多语言文案。
  - 优化解除成功提示为 “Unbanned {count} IP address(es)” 支持单复数显示。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->