### PR TITLE
chore: mount /tmp to container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: "peerbanhelper"
     volumes:
       - ./:/app/data
+      - /tmp:/tmp
     ports:
       - "9898:9898"
     stop_grace_period: 30s


### PR DESCRIPTION
虽然我不理解为什么镜像要将 `/tmp` 公开为持久卷，不过还是修改一下避免每次创建容器时产生一个临时卷。