### PR TITLE
v9.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>9.0.1</version>
+    <version>9.0.2</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/bittorrent/peer/PeerFlag.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/bittorrent/peer/PeerFlag.java
@@ -211,11 +211,11 @@ public final class PeerFlag {
 
     public void parseLibTorrent(String flags) {
         boolean interesting = false;
-        boolean remoteChoked = false;
+        boolean remoteChoked = true;
         boolean remoteInterested = false;
         boolean choked = false;
         boolean optimisticUnchoke = false;
-        boolean snubbed = true;
+        boolean snubbed = false;
         boolean localConnection = true;
         boolean fromDHT = false;
         boolean fromPEX = false;
@@ -253,7 +253,7 @@ public final class PeerFlag {
                     remoteInterested = false;
                 }
                 case 'O' -> optimisticUnchoke = true;
-                case 'S' -> snubbed = false;
+                case 'S' -> snubbed = true;
                 case 'I' -> localConnection = false;
                 case 'H' -> fromDHT = true;
                 case 'X' -> fromPEX = true;

--- a/src/main/java/com/ghostchu/peerbanhelper/bittorrent/peer/PeerFlag.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/bittorrent/peer/PeerFlag.java
@@ -213,7 +213,7 @@ public final class PeerFlag {
         boolean interesting = false;
         boolean remoteChoked = true;
         boolean remoteInterested = false;
-        boolean choked = false;
+        boolean choked = true;
         boolean optimisticUnchoke = false;
         boolean snubbed = false;
         boolean localConnection = true;

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
@@ -70,13 +70,14 @@ public final class PBHLogsController extends AbstractWebSocketFeatureModule {
     }
 
     private void sendHistoryLogs(WsContext ctx, long offset) {
-if (offset > JListAppender.getSeq().longValue()) {// PBH 重启，但是 WebUI 没有刷新，或者为未传递 seq 参数
-    offset = 0;
-    var peekedRecord = JListAppender.ringDeque.peek();
-    if (peekedRecord != null) {
-        offset = peekedRecord.seq() - 1;
-    }
-}
+        if (offset > JListAppender.getSeq().longValue()) {// PBH 重启，但是 WebUI 没有刷新，或者为未传递 seq 参数
+            offset = 0;
+            var peekedRecord = JListAppender.ringDeque.peek();
+            if (peekedRecord != null) {
+                var headSeq = peekedRecord.seq();
+                offset = headSeq - 1;
+            }
+        }
         for (LogEntry logEntry : JListAppender.ringDeque) {
             if (logEntry.seq() > offset) {
                 ctx.send(new StdResp(true, null,

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
@@ -65,13 +65,17 @@ public final class PBHLogsController extends AbstractWebSocketFeatureModule {
     private void handleLogsStream(WsConfig wsConfig) {
         acceptWebSocket(wsConfig, (ctx) -> {
             var offset = ctx.queryParam("offset");
-            sendHistoryLogs(ctx, Long.parseLong(offset == null ? "0" : offset));
+            sendHistoryLogs(ctx, Long.parseLong(offset == null ? String.valueOf(Long.MAX_VALUE) : offset));
         });
     }
 
     private void sendHistoryLogs(WsContext ctx, long offset) {
-        if (offset > JListAppender.getSeq().longValue()) {
-            offset = 0; // PBH 重启，但是 WebUI 没有刷新
+        if (offset > JListAppender.getSeq().longValue()) {// PBH 重启，但是 WebUI 没有刷新，或者为未传递 seq 参数
+            offset = 0;
+            var peekedRecord = JListAppender.ringDeque.peek();
+            if (peekedRecord != null) {
+                offset = peekedRecord.seq();
+            }
         }
         for (LogEntry logEntry : JListAppender.ringDeque) {
             if (logEntry.seq() > offset) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHLogsController.java
@@ -70,13 +70,13 @@ public final class PBHLogsController extends AbstractWebSocketFeatureModule {
     }
 
     private void sendHistoryLogs(WsContext ctx, long offset) {
-        if (offset > JListAppender.getSeq().longValue()) {// PBH 重启，但是 WebUI 没有刷新，或者为未传递 seq 参数
-            offset = 0;
-            var peekedRecord = JListAppender.ringDeque.peek();
-            if (peekedRecord != null) {
-                offset = peekedRecord.seq();
-            }
-        }
+if (offset > JListAppender.getSeq().longValue()) {// PBH 重启，但是 WebUI 没有刷新，或者为未传递 seq 参数
+    offset = 0;
+    var peekedRecord = JListAppender.ringDeque.peek();
+    if (peekedRecord != null) {
+        offset = peekedRecord.seq() - 1;
+    }
+}
         for (LogEntry logEntry : JListAppender.ringDeque) {
             if (logEntry.seq() > offset) {
                 ctx.send(new StdResp(true, null,

--- a/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
@@ -8,28 +8,27 @@ import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.event.program.logger.NewLogEntryCreatedEvent;
 import com.google.common.collect.EvictingQueue;
+import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.event.Level;
 
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 public final class JListAppender extends AppenderBase<ILoggingEvent> {
 
     public static final LinkedBlockingDeque<LogEntry> logEntryDeque = new LinkedBlockingDeque<>(ExternalSwitch.parseInt("pbh.logger.logEntryDeque.size", 200));
     public static final AtomicBoolean allowWriteLogEntryDeque = new AtomicBoolean(true);
     public static final EvictingQueue<LogEntry> ringDeque = EvictingQueue.create(ExternalSwitch.parseInt("pbh.logger.ringDeque.size", 100));
-    private static final AtomicInteger seq = new AtomicInteger(0);
+    @Getter
+    private static final AtomicLong seq = new AtomicLong(0);
     private PatternLayout layout;
     private static final ThrowableProxyConverter converter = new ThrowableProxyConverter();
 
     public JListAppender() {
         converter.start();
-    }
-
-    public static AtomicInteger getSeq() {
-        return seq;
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/util/traversal/stun/TcpStunClient.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/traversal/stun/TcpStunClient.java
@@ -43,7 +43,7 @@ public class TcpStunClient {
         while (true) {
             try {
                 return getMappingFromServer();
-            } catch (ServerUnavailable e) {
+            } catch (Exception e) {
                 // 轮换到下一个服务器
                 currentServerIndex = (currentServerIndex + 1) % stunServerList.size();
                 // 如果回到第一个服务器，说明所有服务器都试过了

--- a/webui/src/api/model/status.ts
+++ b/webui/src/api/model/status.ts
@@ -35,7 +35,11 @@ export type RunningInfo = {
     }
     load: number
     network: {
-      internet_access: boolean
+      internet_access: {
+        accessToChinaNetwork: boolean
+        accessToGlobalNetwork: boolean
+      }
+      nat_type: string
       use_proxy: boolean
       reverse_proxy: boolean
       client_ip: string

--- a/webui/src/components/plus/plusModalContainer.vue
+++ b/webui/src/components/plus/plusModalContainer.vue
@@ -49,7 +49,24 @@
             <a-space style="display: flex; justify-content: center; align-items: center">
               <a-typography-text type="secondary">{{ t('plus.or') }}</a-typography-text>
               &nbsp;
-              <a-button :loading="loading" @click="handleTry">
+              <a-tooltip v-if="!canGenerateTry">
+                <template #content>
+                  <i18n-t keypath="plus.try.unavailable.desc">
+                    <template #detail>
+                      <a-link
+                        :href="t('plus.try.unavailable.desc.detail.url')"
+                        target="_blank"
+                        style="text-decoration: underline"
+                        >{{ t('plus.try.unavailable.desc.detail') }}</a-link
+                      >
+                    </template>
+                  </i18n-t>
+                </template>
+                <a-button disabled>
+                  <template #icon><icon-close /></template>{{ t('plus.try.unavailable') }}
+                </a-button>
+              </a-tooltip>
+              <a-button v-else :loading="loading" @click="handleTry">
                 <template #icon><icon-face-frown-fill /></template>{{ t('plus.try') }}
               </a-button>
             </a-space>
@@ -137,6 +154,7 @@ defineExpose({
     showModal.value = true
   }
 })
+const canGenerateTry = window.isSecureContext
 
 const loading = ref(false)
 const submitKey = async (key: string) => {

--- a/webui/src/locale/en-US/plus.ts
+++ b/webui/src/locale/en-US/plus.ts
@@ -23,6 +23,12 @@ export default {
 
   'plus.or': 'Or',
   'plus.try': "I don't want to donate",
+  'plus.try.unavailable': 'Local license unavailable',
+  'plus.try.unavailable.desc':
+    'Due to browser restrictions, you cannot generate a local license in the current window (non-secure context). Click to see {detail}.',
+  'plus.try.unavailable.desc.detail': 'details',
+  'plus.try.unavailable.desc.detail.url':
+    'https://developer.mozilla.org/en-US/docs/Web/API/Crypto/subtle',
 
   'plus.tryModal.title': 'Get Plus subscription for free',
   'plus.tryModal.content1':

--- a/webui/src/locale/zh-CN/plus.ts
+++ b/webui/src/locale/zh-CN/plus.ts
@@ -23,6 +23,12 @@ export default {
 
   'plus.or': '或者',
   'plus.try': '我不想捐赠',
+  'plus.try.unavailable': '本地许可证不可用',
+  'plus.try.unavailable.desc':
+    '由于浏览器限制，您不能在当前窗口（非安全上下文）中生成本地许可证，点击{detail}',
+  'plus.try.unavailable.desc.detail': '查看详情',
+  'plus.try.unavailable.desc.detail.url':
+    'https://developer.mozilla.org/zh-CN/docs/Web/API/Crypto/subtle',
 
   'plus.tryModal.title': '免费激活 Plus 订阅',
   'plus.tryModal.content1':

--- a/webui/src/locale/zh-TW/plus.ts
+++ b/webui/src/locale/zh-TW/plus.ts
@@ -23,6 +23,12 @@ export default {
 
   'plus.or': '或者',
   'plus.try': '我不想捐贈',
+  'plus.try.unavailable': '本地許可證不可用',
+  'plus.try.unavailable.desc':
+    '由於瀏覽器限制，您不能在當前視窗（非安全上下文）中生成本地許可證，點擊{detail}',
+  'plus.try.unavailable.desc.detail': '查看詳情',
+  'plus.try.unavailable.desc.detail.url':
+    'https://developer.mozilla.org/zh-CN/docs/Web/API/Crypto/subtle',
 
   'plus.tryModal.title': '免費啟用 Plus 訂閱',
   'plus.tryModal.content1':

--- a/webui/src/views/charts/components/plusWarpper.vue
+++ b/webui/src/views/charts/components/plusWarpper.vue
@@ -1,9 +1,5 @@
 <template>
-  <slot
-    v-if="
-      endpointStore.plusStatus?.enabledFeatures?.includes('basic')
-    "
-  ></slot>
+  <slot v-if="endpointStore.plusStatus?.enabledFeatures?.includes('basic')"></slot>
   <a-card v-else hoverable :title="title">
     <a-result class="overlay" status="warning" :title="t('page.charts.locked')">
       <template #icon>

--- a/webui/src/views/custom-script/components/editor/index.vue
+++ b/webui/src/views/custom-script/components/editor/index.vue
@@ -50,7 +50,7 @@ const model = defineModel<string | undefined>({ required: true })
 
 loader.config({
   paths: {
-    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.53.0/min/vs'
+    vs: 'https://cdn.jsdelivr.net/npm/monaco-editor@0.52.2/min/vs'
   }
 })
 const AV = 'aviatorscript'

--- a/webui/src/views/data-view/ipList/index.vue
+++ b/webui/src/views/data-view/ipList/index.vue
@@ -256,9 +256,8 @@ onMounted(() => {
   }
 })
 
-const pbhPlusActivited = computed(
-  () =>
-    endpointStore.plusStatus?.enabledFeatures?.includes('basic')
+const pbhPlusActivited = computed(() =>
+  endpointStore.plusStatus?.enabledFeatures?.includes('basic')
 )
 </script>
 <style>

--- a/webui/src/views/data-view/torrentList/components/torrentTable.vue
+++ b/webui/src/views/data-view/torrentList/components/torrentTable.vue
@@ -187,9 +187,8 @@ const columns = [
 const list = computed(() => data.value?.data.results)
 const accessHistoryModal = ref<InstanceType<typeof AccessHistoryModal>>()
 const banHistoryModal = ref<InstanceType<typeof BanHistoryModal>>()
-const pbhPlusActivited = computed(
-  () =>
-    endpointStore.plusStatus?.enabledFeatures?.includes('basic')
+const pbhPlusActivited = computed(() =>
+  endpointStore.plusStatus?.enabledFeatures?.includes('basic')
 )
 
 const handleSearch = debounce((value: string) => {

--- a/webui/src/views/settings/components/info/index.vue
+++ b/webui/src/views/settings/components/info/index.vue
@@ -306,12 +306,7 @@
           :align="{ label: 'right' }"
         >
           <a-descriptions-item :label="t('page.settings.tab.info.network.internet')">
-            Unknown
-            <!-- {{
-          data?.data.system.network.internet_access
-            ? t('page.settings.tab.info.network.yes')
-            : t('page.settings.tab.info.network.no')
-        }} -->
+            {{ networkAccess(data?.data) }}
           </a-descriptions-item>
           <a-descriptions-item :label="t('page.settings.tab.info.network.proxy')">
             {{
@@ -499,7 +494,7 @@
   </a-modal>
 </template>
 <script setup lang="ts">
-import { OSType } from '@/api/model/status'
+import { OSType, type RunningInfo } from '@/api/model/status'
 import { genIconComponent } from '@/components/iconFont'
 import multiClick from '@/components/multiClick.vue'
 import {
@@ -591,9 +586,8 @@ const isClientIpLocal = computed(() => {
   return false
 })
 
-const pbhPlusActivited = computed(
-  () =>
-    endpointStore.plusStatus?.enabledFeatures?.includes('basic')
+const pbhPlusActivited = computed(() =>
+  endpointStore.plusStatus?.enabledFeatures?.includes('basic')
 )
 
 const osLogo = {
@@ -617,6 +611,25 @@ const downloadHeap = () => {
     a.download = 'heapdump.hprof.gz'
     a.click()
   }, 1000)
+}
+
+const networkAccess = (runningInfo: RunningInfo | undefined) => {
+  if (runningInfo === undefined) return 'N/A'
+  const network = runningInfo.system.network
+  const internetAccess = network.internet_access
+  let i18nString = '???'
+
+  if (!internetAccess.accessToChinaNetwork && !internetAccess.accessToGlobalNetwork) {
+    i18nString = 'page.settings.tab.info.network.internet.no'
+  } else if (internetAccess.accessToChinaNetwork && !internetAccess.accessToGlobalNetwork) {
+    i18nString = 'page.settings.tab.info.network.internet.cnOnly'
+  } else if (!internetAccess.accessToChinaNetwork && internetAccess.accessToGlobalNetwork) {
+    i18nString = 'page.settings.tab.info.network.internet.globalOnly'
+  } else if (internetAccess.accessToChinaNetwork && internetAccess.accessToGlobalNetwork) {
+    i18nString = 'page.settings.tab.info.network.internet.full'
+  }
+
+  return t(i18nString, { nat: network.nat_type })
 }
 </script>
 

--- a/webui/src/views/settings/components/info/locale/en-US.ts
+++ b/webui/src/views/settings/components/info/locale/en-US.ts
@@ -34,6 +34,10 @@ export default {
     'PBH has obtained a local IP address, which usually does not expected and indicates that your reverse proxy configuration is incorrect. Please check it.',
   'page.settings.tab.info.network.yes': 'Yes',
   'page.settings.tab.info.network.no': 'No',
+  'page.settings.tab.info.network.internet.no': 'No Internet Access (NAT Type: {nat})',
+  'page.settings.tab.info.network.internet.cnOnly': 'China Internet Access (NAT Type: {nat})',
+  'page.settings.tab.info.network.internet.globalOnly': 'Global Internet Access (NAT Type: {nat})',
+  'page.settings.tab.info.network.internet.full': 'Full Internet Access (NAT Type: {nat})',
 
   'page.settings.tab.info.runtime': 'Runtime Info',
   'page.settings.tab.info.runtime.version': 'JVM Version',

--- a/webui/src/views/settings/components/info/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/info/locale/zh-CN.ts
@@ -34,6 +34,10 @@ export default {
     'PBH 获取到了一个本地的 IP 地址，这通常是非预期的并意味着您的反向代理配置有误，请检查您的反向代理配置',
   'page.settings.tab.info.network.yes': '是',
   'page.settings.tab.info.network.no': '否',
+  'page.settings.tab.info.network.internet.no': '无 Internet 访问 (NAT 类型: {nat})',
+  'page.settings.tab.info.network.internet.cnOnly': 'China Internet 访问 (NAT 类型: {nat})',
+  'page.settings.tab.info.network.internet.globalOnly': 'Global Internet 访问 (NAT 类型: {nat})',
+  'page.settings.tab.info.network.internet.full': 'Full Internet 访问 (NAT 类型: {nat})',
 
   'page.settings.tab.info.runtime': '运行时信息',
   'page.settings.tab.info.runtime.version': 'JVM 版本',

--- a/webui/src/views/settings/components/info/locale/zh-TW.ts
+++ b/webui/src/views/settings/components/info/locale/zh-TW.ts
@@ -34,6 +34,10 @@ export default {
     'PBH 獲取到了一個本機的 IP 位址，這通常是非預期的並意味著您的反向代理配置有誤，請檢查您的反向代理配置',
   'page.settings.tab.info.network.yes': '是',
   'page.settings.tab.info.network.no': '否',
+  'page.settings.tab.info.network.internet.no': '無 Internet 存取 (NAT 類型: {nat})',
+  'page.settings.tab.info.network.internet.cnOnly': 'China Internet 存取 (NAT 類型: {nat})',
+  'page.settings.tab.info.network.internet.globalOnly': 'Global Internet 存取 (NAT 類型: {nat})',
+  'page.settings.tab.info.network.internet.full': 'Full Internet 存取 (NAT 類型: {nat})',
 
   'page.settings.tab.info.runtime': '執行階段資訊',
   'page.settings.tab.info.runtime.version': 'JVM 版本',


### PR DESCRIPTION
## 错误修复

1. 修复 qBittorrent <= 5.1.2 版本中，当活动种子数量恰好为 100 的倍数时，因 https://github.com/qbittorrent/qBittorrent/issues/22158 错误导致 PeerBanHelper 陷入死循环并导致内存泄漏的问题 @paulzzh 
2. 修复 PeerFlag 的两个字段解析问题 @paulzzh 
3. 修复 Avaitor Script Editor 加载失败的问题 @Gaojianli 
4. 修复了 renew 许可时可能出现 PoW 挑战失败的问题。由于浏览器安全上下文限制，请通过 localhost 访问或者添加 HTTPS 代理 @Gaojianli 
5. 修复 STUN 服务器集中一个服务器返回非预期响应时会导致整个 NAT 探测中断失败 @Ghost-chu 
6. 修复 WebUI 的 Internet 访问字段固定为 Unknown 的问题 @Ghost-chu 
7. 修复 WebUI 的日志在一段时间后停止工作的问题 @Ghost-chu 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 设置页显示更细粒度的网络连通性（中国/全球）与 NAT 类型
  - 非安全环境下禁用“Plus 试用”按钮并提供说明与详情链接
  - 新增相关中/英/繁多语言文案
- Bug 修复
  - qBittorrent 分页去重与停止条件优化，避免列表重复或漏项
  - 重启后日志流可从最新位置继续
  - STUN 错误处理更健壮，提升连通性检测稳定性
- 杂务
  - 版本升级至 9.0.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->