### PR TITLE
v9.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>9.0.2</version>
+    <version>9.0.3-25w39a</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>9.0.3-25w39a</version>
+    <version>9.0.3</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
@@ -106,7 +106,6 @@ public final class DownloaderServerImpl implements Reloadable, AutoCloseable, Do
         this.databaseManager = databaseManager;
         Main.getReloadManager().register(this);
         loadBanListToMemory();
-        load();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -25,6 +25,11 @@ public final class ProfileUpdateScript {
         this.conf = conf;
     }
 
+    @UpdateScript(version = 32)
+    public void fixSwarmTracking(YamlConfiguration bundled) {
+        conf.set("module.swarm-tracking", bundled.get("module.swarm-tracking"));
+    }
+
     @UpdateScript(version = 31)
     public void idleConnectionDosProtectionUpdate(YamlConfiguration bundled) {
         conf.set("module.idle-connection-dos-protection", bundled.get("module.idle-connection-dos-protection"));

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.downloader;
 
+import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.alert.AlertManager;
 import com.ghostchu.peerbanhelper.text.Lang;
@@ -128,7 +129,7 @@ public abstract class AbstractDownloader implements Downloader {
 
     @Override
     public int getMaxConcurrentPeerRequestSlots() {
-        return 16;
+        return ExternalSwitch.parseInt("pbh.downloader.AbstractDownloader.maxConcurrentPeerRequestSlots", 16);
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -310,7 +310,7 @@ public final class BiglyBT extends AbstractDownloader {
 
     @Override
     public int getMaxConcurrentPeerRequestSlots() {
-        return ExternalSwitch.parseInt("pbh.downloader.qBittorrent.maxConcurrentPeerRequestSlots", 128);
+        return ExternalSwitch.parseInt("pbh.downloader.BiglyBT.maxConcurrentPeerRequestSlots", 128);
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.downloader.impl.biglybt;
 
+import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.alert.AlertManager;
 import com.ghostchu.peerbanhelper.bittorrent.peer.Peer;
@@ -26,7 +27,6 @@ import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
 import com.ghostchu.peerbanhelper.util.ByteUtil;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
-import com.ghostchu.peerbanhelper.util.IPAddressUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.traversal.NatAddressProvider;
 import com.ghostchu.peerbanhelper.wrapper.BanMetadata;
@@ -306,6 +306,11 @@ public final class BiglyBT extends AbstractDownloader {
         } catch (IOException e) {
             throw new DownloaderRequestException(e);
         }
+    }
+
+    @Override
+    public int getMaxConcurrentPeerRequestSlots() {
+        return ExternalSwitch.parseInt("pbh.downloader.qBittorrent.maxConcurrentPeerRequestSlots", 128);
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.downloader.impl.deluge;
 
+import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.alert.AlertManager;
 import com.ghostchu.peerbanhelper.bittorrent.peer.Peer;
 import com.ghostchu.peerbanhelper.bittorrent.peer.PeerFlag;
@@ -104,6 +105,11 @@ public final class Deluge extends AbstractDownloader {
     public void setPaused(boolean paused) {
         super.setPaused(paused);
         config.setPaused(paused);
+    }
+
+    @Override
+    public int getMaxConcurrentPeerRequestSlots() {
+        return ExternalSwitch.parseInt("pbh.downloader.Deluge.maxConcurrentPeerRequestSlots", 32);
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
@@ -84,6 +84,8 @@ public abstract class AbstractQbittorrent extends AbstractDownloader {
 
     @Override
     public int getMaxConcurrentPeerRequestSlots() {
+        // qBittorrent Http Server 的 Connection Limit 是 500
+        // https://github.com/qbittorrent/qBittorrent/blob/3de2a9f486a77a911fab986daabbe50ce7c85b04/src/base/http/server.cpp#L57
         return ExternalSwitch.parseInt("pbh.downloader.qBittorrent.maxConcurrentPeerRequestSlots", 128);
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
@@ -77,7 +77,7 @@ public abstract class AbstractQbittorrent extends AbstractDownloader {
 
         YamlConfiguration profileConfig = Main.getProfileConfig();
         this.torrentPropertiesCache = CacheBuilder.newBuilder()
-                .maximumSize(2000)
+                //.maximumSize(2000)
                 .expireAfterAccess(
                         profileConfig.getLong("check-interval", 5000) + (1000 * 60),
                         TimeUnit.MILLISECONDS

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.downloader.impl.qbittorrent;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.Main;
 import com.ghostchu.peerbanhelper.alert.AlertManager;
 import com.ghostchu.peerbanhelper.bittorrent.peer.Peer;
@@ -80,6 +81,12 @@ public abstract class AbstractQbittorrent extends AbstractDownloader {
                 )
                 .build();
     }
+
+    @Override
+    public int getMaxConcurrentPeerRequestSlots() {
+        return ExternalSwitch.parseInt("pbh.downloader.qBittorrent.maxConcurrentPeerRequestSlots", 128);
+    }
+
 
     @Override
     public @NotNull String getName() {

--- a/src/main/java/com/ghostchu/peerbanhelper/gui/impl/console/ConsoleGuiImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/gui/impl/console/ConsoleGuiImpl.java
@@ -27,12 +27,13 @@ public class ConsoleGuiImpl implements GuiImpl {
     @Override
     public void setup() {
         System.setProperty("java.awt.headless", "true");
+        JListAppender.allowWriteLogEntryDeque.set(false);
+        JListAppender.logEntryDeque.clear();
     }
 
     @Override
     public void createMainWindow() {
-        JListAppender.allowWriteLogEntryDeque.set(false);
-        JListAppender.logEntryDeque.clear();
+
     }
 
     @SneakyThrows

--- a/src/main/java/com/ghostchu/peerbanhelper/util/HTTPUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/HTTPUtil.java
@@ -154,6 +154,7 @@ public final class HTTPUtil implements Reloadable {
                 .dispatcher(new Dispatcher(Executors.newVirtualThreadPerTaskExecutor()))
                 .connectTimeout(15, TimeUnit.SECONDS)
                 .followRedirects(true)
+                .connectionPool(new ConnectionPool(5, 5, TimeUnit.MINUTES))
                 .followSslRedirects(true)
                 .fastFallback(true)
                 .retryOnConnectionFailure(true)

--- a/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
@@ -12,14 +12,12 @@ import lombok.Getter;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.event.Level;
 
-import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 
 public final class JListAppender extends AppenderBase<ILoggingEvent> {
 
-    public static final LinkedBlockingDeque<LogEntry> logEntryDeque = new LinkedBlockingDeque<>(ExternalSwitch.parseInt("pbh.logger.logEntryDeque.size", 200));
+    public static final EvictingQueue<LogEntry> logEntryDeque = EvictingQueue.create(ExternalSwitch.parseInt("pbh.logger.logEntryDeque.size", 200));
     public static final AtomicBoolean allowWriteLogEntryDeque = new AtomicBoolean(true);
     public static final EvictingQueue<LogEntry> ringDeque = EvictingQueue.create(ExternalSwitch.parseInt("pbh.logger.ringDeque.size", 100));
     @Getter

--- a/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/logger/JListAppender.java
@@ -51,13 +51,14 @@ public final class JListAppender extends AppenderBase<ILoggingEvent> {
         } else if (eventObject.getLevel() == ch.qos.logback.classic.Level.OFF) {
             return;
         }
+        long seqNumber = seq.incrementAndGet();
         if (allowWriteLogEntryDeque.get()) {
             var postAccessLog = new LogEntry(
                     eventObject.getTimeStamp(),
                     eventObject.getThreadName(),
                     slf4jLevel,
                     formattedMessage.trim(),
-                    seq.incrementAndGet());
+                    seqNumber);
             logEntryDeque.add(postAccessLog);
         }
         var rawLog = new LogEntry(
@@ -65,7 +66,7 @@ public final class JListAppender extends AppenderBase<ILoggingEvent> {
                 eventObject.getThreadName(),
                 slf4jLevel,
                 formattedMessage.startsWith("[") ? StringUtils.substringAfter(formattedMessage.trim(), ": ") : formattedMessage.trim(),
-                seq.incrementAndGet());
+                seqNumber);
         ringDeque.add(rawLog);
         Main.getEventBus().post(new NewLogEntryCreatedEvent(rawLog));
     }

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -457,7 +457,7 @@ module:
     # 规则从上到下执行
     ptr-rules:
       - '{"method":"EQUALS","content":"example.com"}'
-  peers-local-track:
+  swarm-tracking:
     enabled: true
   # 拒绝服务攻击保护模块 - DoS Protection Module
   # 此模块保护与 PeerBanHelper 关联的下载器的拒绝服务攻击


### PR DESCRIPTION
## 错误修复

* 修复 downloaderServer#load 会被调用两次的问题 #1378 @paulzzh 
* 修复 GUI 未启用的情况下，WebUI 的日志会在一段时间后停止更新的问题，并可能伴随 CPU 使用率上升 @Ghost-chu 
* 调整 qBittorrent 的默认并发请求数从 `16` 到 `128` 以缩短数据获取耗时 @Ghost-chu 
* 修复因配置文件升级脚本错误，Swarm Tracking 模块没有正常工作的问题 @Ghost-chu 

## 杂项更改

* qBittorrent 的 Torrent Properties 缓存的最大大小设置现已被取消，避免因频繁缓存逐出额外请求 API
  * 使用较新版本的 qBittorrent 用户可忽略此更改，在较新版本上无需请求 Torrent Properties