### PR TITLE
v9.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.ghostchu.peerbanhelper</groupId>
     <artifactId>peerbanhelper</artifactId>
-    <version>9.0.3</version>
+    <version>9.0.4</version>
     <packaging>jar</packaging>
 
     <name>PeerBanHelper</name>

--- a/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
@@ -105,7 +105,6 @@ public final class DownloaderServerImpl implements Reloadable, AutoCloseable, Do
         this.alertManager = alertManager;
         this.databaseManager = databaseManager;
         Main.getReloadManager().register(this);
-        loadBanListToMemory();
     }
 
     @Override
@@ -147,7 +146,7 @@ public final class DownloaderServerImpl implements Reloadable, AutoCloseable, Do
         );
     }
 
-    private void loadBanListToMemory() {
+    public void loadBanListToMemory() {
         if (!Main.getMainConfig().getBoolean("persist.banlist")) {
             return;
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/DownloaderServerImpl.java
@@ -137,13 +137,15 @@ public final class DownloaderServerImpl implements Reloadable, AutoCloseable, Do
     }
 
     private void unbanWhitelistedPeers() {
+        List<IPAddress> list = new ArrayList<>();
         banList.forEach((addr, meta) -> {
                     var node = ignoreAddresses.elementsContaining(addr);
                     if (node != null) {
-                        scheduleUnBanPeer(addr);
+                        list.add(addr);
                     }
                 }
         );
+        list.forEach(this::scheduleUnBanPeer);
     }
 
     public void loadBanListToMemory() {

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelper.java
@@ -16,7 +16,6 @@ import com.ghostchu.peerbanhelper.module.impl.webapi.*;
 import com.ghostchu.peerbanhelper.platform.win32.workingset.jna.WorkingSetManagerFactory;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
-import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.ipdb.IPDBManager;
 import com.ghostchu.peerbanhelper.web.JavalinWebContainer;
 import com.ghostchu.simplereloadlib.ReloadResult;
@@ -82,6 +81,7 @@ public class PeerBanHelper implements Reloadable {
         registerModules();
         sendSnapshotAlert();
         downloaderServer.load();
+        downloaderServer.loadBanListToMemory();
         Main.getGuiManager().taskbarControl().updateProgress(null, TaskbarState.OFF, 0.0f);
         crashManager.putRunningFlag();
         Main.getEventBus().post(new PBHServerStartedEvent());

--- a/src/main/java/com/ghostchu/peerbanhelper/btn/ability/impl/BtnAbilityException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/ability/impl/BtnAbilityException.java
@@ -13,16 +13,19 @@ import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.rule.Rule;
 import com.ghostchu.peerbanhelper.util.rule.RuleMatchResult;
 import com.ghostchu.peerbanhelper.util.rule.RuleParser;
-import okhttp3.*;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonSyntaxException;
+import inet.ipaddr.IPAddress;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.Request;
+import okhttp3.Response;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -160,50 +163,58 @@ public final class BtnAbilityException extends AbstractBtnAbility {
 
     private int unbanIps(List<Rule> rules) {
         AtomicInteger ct = new AtomicInteger(0);
+        List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, addr.toNormalizedString());
             if (matchResult.hit()) {
-                btnNetwork.getServer().scheduleUnBanPeer(addr);
+                list.add(addr);
                 ct.incrementAndGet();
             }
         });
+        list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
         return ct.get();
     }
 
     private int unbanClientName(List<Rule> rules) {
         AtomicInteger ct = new AtomicInteger(0);
+        List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, meta.getPeer().getClientName());
             if (matchResult.hit()) {
-                btnNetwork.getServer().scheduleUnBanPeer(addr);
+                list.add(addr);
                 ct.incrementAndGet();
             }
         });
+        list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
 
         return ct.get();
     }
 
     private int unbanPeerId(List<Rule> rules) {
         AtomicInteger ct = new AtomicInteger(0);
+        List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, meta.getPeer().getId());
             if (matchResult.hit()) {
-                btnNetwork.getServer().scheduleUnBanPeer(addr);
+                list.add(addr);
                 ct.incrementAndGet();
             }
         });
+        list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
         return ct.get();
     }
 
     private int unbanPort(List<Rule> rules) {
         AtomicInteger ct = new AtomicInteger(0);
+        List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, Integer.toString(meta.getPeer().getAddress().getPort()));
             if (matchResult.hit()) {
-                btnNetwork.getServer().scheduleUnBanPeer(addr);
+                list.add(addr);
                 ct.incrementAndGet();
             }
         });
+        list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
         return ct.get();
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/btn/ability/impl/BtnAbilityException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/ability/impl/BtnAbilityException.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static com.ghostchu.peerbanhelper.text.TextManager.tlUI;
 
@@ -162,60 +161,52 @@ public final class BtnAbilityException extends AbstractBtnAbility {
     }
 
     private int unbanIps(List<Rule> rules) {
-        AtomicInteger ct = new AtomicInteger(0);
         List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, addr.toNormalizedString());
             if (matchResult.hit()) {
                 list.add(addr);
-                ct.incrementAndGet();
             }
         });
         list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
-        return ct.get();
+        return list.size();
     }
 
     private int unbanClientName(List<Rule> rules) {
-        AtomicInteger ct = new AtomicInteger(0);
         List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, meta.getPeer().getClientName());
             if (matchResult.hit()) {
                 list.add(addr);
-                ct.incrementAndGet();
             }
         });
         list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
 
-        return ct.get();
+        return list.size();
     }
 
     private int unbanPeerId(List<Rule> rules) {
-        AtomicInteger ct = new AtomicInteger(0);
         List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, meta.getPeer().getId());
             if (matchResult.hit()) {
                 list.add(addr);
-                ct.incrementAndGet();
             }
         });
         list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
-        return ct.get();
+        return list.size();
     }
 
     private int unbanPort(List<Rule> rules) {
-        AtomicInteger ct = new AtomicInteger(0);
         List<IPAddress> list = new ArrayList<>();
         btnNetwork.getServer().getBanList().forEach((addr, meta) -> {
             RuleMatchResult matchResult = RuleParser.matchRule(rules, Integer.toString(meta.getPeer().getAddress().getPort()));
             if (matchResult.hit()) {
                 list.add(addr);
-                ct.incrementAndGet();
             }
         });
         list.forEach(addr -> btnNetwork.getServer().scheduleUnBanPeer(addr));
-        return ct.get();
+        return list.size();
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/PBHPluginManager.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/PBHPluginManager.java
@@ -1,0 +1,118 @@
+package com.ghostchu.peerbanhelper.configuration.pf4j;
+
+import org.pf4j.*;
+import org.pf4j.util.FileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+public class PBHPluginManager extends AbstractPluginManager {
+
+    private static final Logger log = LoggerFactory.getLogger(PBHPluginManager.class);
+
+    public static final String PLUGINS_DIR_CONFIG_PROPERTY_NAME = "pf4j.pluginsConfigDir";
+
+    public PBHPluginManager() {
+        super();
+    }
+
+    public PBHPluginManager(Path... pluginsRoots) {
+        super(pluginsRoots);
+    }
+
+    public PBHPluginManager(List<Path> pluginsRoots) {
+        super(pluginsRoots);
+    }
+
+    @Override
+    protected PluginDescriptorFinder createPluginDescriptorFinder() {
+        return new CompoundPluginDescriptorFinder()
+                .add(new PropertiesPluginDescriptorFinder())
+                .add(new ManifestPluginDescriptorFinder());
+    }
+
+    @Override
+    protected ExtensionFinder createExtensionFinder() {
+        DefaultExtensionFinder extensionFinder = new DefaultExtensionFinder(this);
+        addPluginStateListener(extensionFinder);
+
+        return extensionFinder;
+    }
+
+    @Override
+    protected PluginFactory createPluginFactory() {
+        return new DefaultPluginFactory();
+    }
+
+    @Override
+    protected ExtensionFactory createExtensionFactory() {
+        return new DefaultExtensionFactory();
+    }
+
+    @Override
+    protected PluginStatusProvider createPluginStatusProvider() {
+        String configDir = System.getProperty(PLUGINS_DIR_CONFIG_PROPERTY_NAME);
+        Path configPath = configDir != null
+                ? Paths.get(configDir)
+                : getPluginsRoots().stream()
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("No pluginsRoot configured"));
+
+        return new DefaultPluginStatusProvider(configPath);
+    }
+
+    @Override
+    protected PluginRepository createPluginRepository() {
+        return new CompoundPluginRepository()
+                .add(new DevelopmentPluginRepository(getPluginsRoots()), this::isDevelopment)
+                .add(new JarPluginRepository(getPluginsRoots()), this::isNotDevelopment)
+                .add(new DefaultPluginRepository(getPluginsRoots()), this::isNotDevelopment);
+    }
+
+    @Override
+    protected PluginLoader createPluginLoader() {
+        return new CompoundPluginLoader()
+                .add(new DevelopmentPluginLoader(this), this::isDevelopment)
+                .add(new JarPluginLoader(this), this::isNotDevelopment)
+                .add(new DefaultPluginLoader(this), this::isNotDevelopment);
+    }
+
+    @Override
+    protected VersionManager createVersionManager() {
+        return new DefaultVersionManager();
+    }
+
+    @Override
+    protected void initialize() {
+        super.initialize();
+
+        if (isDevelopment()) {
+            addPluginStateListener(new LoggingPluginStateListener());
+        }
+
+        log.info("PF4J version {} in '{}' mode", getVersion(), getRuntimeMode());
+    }
+
+    /**
+     * Load a plugin from disk. If the path is a zip file, first unpack.
+     *
+     * @param pluginPath plugin location on disk
+     * @return PluginWrapper for the loaded plugin or null if not loaded
+     * @throws PluginRuntimeException if problems during load
+     */
+    @Override
+    protected PluginWrapper loadPluginFromPath(Path pluginPath) {
+        // First unzip any ZIP files
+        try {
+            pluginPath = FileUtils.expandIfZip(pluginPath);
+        } catch (Exception e) {
+            log.warn("Failed to unzip " + pluginPath, e);
+            return null;
+        }
+
+        return super.loadPluginFromPath(pluginPath);
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/PBHSpringPluginManager.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/PBHSpringPluginManager.java
@@ -1,0 +1,114 @@
+package com.ghostchu.peerbanhelper.configuration.pf4j;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.pf4j.ExtensionFactory;
+import org.pf4j.PluginState;
+import org.pf4j.PluginStateEvent;
+import org.pf4j.PluginWrapper;
+import org.pf4j.spring.ExtensionsInjector;
+import org.pf4j.spring.SpringExtensionFactory;
+import org.pf4j.spring.SpringPluginManager;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+@Slf4j
+public class PBHSpringPluginManager extends SpringPluginManager implements ApplicationContextAware {
+    private ApplicationContext applicationContext;
+
+    public PBHSpringPluginManager() {
+        super();
+    }
+
+    public PBHSpringPluginManager(Path... pluginsRoots) {
+        super(pluginsRoots);
+    }
+
+    public PBHSpringPluginManager(List<Path> pluginsRoots) {
+        super(pluginsRoots);
+    }
+
+    @Override
+    protected ExtensionFactory createExtensionFactory() {
+        return new SpringExtensionFactory(this);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext applicationContext) throws BeansException {
+        this.applicationContext = applicationContext;
+    }
+
+    public ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    /**
+     * This method load, start plugins and inject extensions in Spring
+     */
+    @PostConstruct
+    public void init() {
+        loadPlugins();
+        startPlugins();
+
+        AbstractAutowireCapableBeanFactory beanFactory = (AbstractAutowireCapableBeanFactory) applicationContext.getAutowireCapableBeanFactory();
+        ExtensionsInjector extensionsInjector = new ExtensionsInjector(this, beanFactory);
+        extensionsInjector.injectExtensions();
+    }
+
+    @Override
+    public void startPlugins() {
+        for (PluginWrapper pluginWrapper : resolvedPlugins) {
+            PluginState pluginState = pluginWrapper.getPluginState();
+            if (!pluginState.isDisabled() && !pluginState.isStarted()) {
+                try {
+                    log.info("Start plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
+                    pluginWrapper.getPlugin().start();
+                    pluginWrapper.setPluginState(PluginState.STARTED);
+                    pluginWrapper.setFailedException(null);
+                    startedPlugins.add(pluginWrapper);
+                } catch (Throwable e) {
+                    pluginWrapper.setPluginState(PluginState.FAILED);
+                    pluginWrapper.setFailedException(e);
+                    log.error("Unable to start plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()), e);
+                } finally {
+                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
+                }
+            }
+        }
+    }
+    /**
+     * Stop all active plugins.
+     */
+    @Override
+    public void stopPlugins() {
+        // stop started plugins in reverse order
+        Collections.reverse(startedPlugins);
+        Iterator<PluginWrapper> itr = startedPlugins.iterator();
+        while (itr.hasNext()) {
+            PluginWrapper pluginWrapper = itr.next();
+            PluginState pluginState = pluginWrapper.getPluginState();
+            if (pluginState.isStarted()) {
+                try {
+                    log.info("Stop plugin '{}'", getPluginLabel(pluginWrapper.getDescriptor()));
+                    pluginWrapper.getPlugin().stop();
+                    pluginWrapper.setPluginState(PluginState.STOPPED);
+                    itr.remove();
+
+                    firePluginStateEvent(new PluginStateEvent(this, pluginWrapper, pluginState));
+                } catch (Throwable e) {
+                    log.error(e.getMessage(), e);
+                }
+            } else {
+                // do nothing
+                log.debug("Plugin '{}' is not started, nothing to stop", getPluginLabel(pluginWrapper.getDescriptor()));
+            }
+        }
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/Pf4jConfiguration.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/configuration/pf4j/Pf4jConfiguration.java
@@ -1,8 +1,7 @@
-package com.ghostchu.peerbanhelper.configuration;
+package com.ghostchu.peerbanhelper.configuration.pf4j;
 
 import com.ghostchu.peerbanhelper.Main;
 import org.pf4j.PluginManager;
-import org.pf4j.spring.SpringPluginManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -14,7 +13,7 @@ public class Pf4jConfiguration {
 
     @Bean
     public PluginManager pluginManager() {
-        return new SpringPluginManager(Main.getPluginDirectory().toPath());
+        return new PBHSpringPluginManager(Main.getPluginDirectory().toPath());
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/database/table/tmp/TrackedSwarmEntity.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/database/table/tmp/TrackedSwarmEntity.java
@@ -24,6 +24,8 @@ public final class TrackedSwarmEntity { // 需要创建为临时表
     private String infoHash;
     @DatabaseField(canBeNull = false, index = true)
     private Boolean torrentIsPrivate;
+    @DatabaseField(canBeNull = false, index = true)
+    private long torrentSize;
     @DatabaseField(canBeNull = false, uniqueCombo = true)
     private String downloader;
     @DatabaseField(canBeNull = false)

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -310,7 +310,7 @@ public final class BiglyBT extends AbstractDownloader {
 
     @Override
     public int getMaxConcurrentPeerRequestSlots() {
-        return ExternalSwitch.parseInt("pbh.downloader.qBittorrent.maxConcurrentPeerRequestSlots", 128);
+        return ExternalSwitch.parseInt("pbh.downloader.BiglyBT.maxConcurrentPeerRequestSlots", 128);
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/gui/impl/swing/mainwindow/component/swtembed/SwtBrowserCanvas.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/gui/impl/swing/mainwindow/component/swtembed/SwtBrowserCanvas.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.gui.impl.swing.mainwindow.component.swtembed;
 
 import com.ghostchu.peerbanhelper.Main;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.SWTError;
 import org.eclipse.swt.awt.SWT_AWT;
@@ -14,6 +15,7 @@ import java.awt.event.ComponentEvent;
 import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
+@Slf4j
 public final class SwtBrowserCanvas extends Canvas {
     private final Thread swtEventLoop;
     private Display display;
@@ -47,7 +49,7 @@ public final class SwtBrowserCanvas extends Canvas {
         // SWT Hi-DPI 支持
         System.setProperty("swt.autoScale", "exact");
         System.setProperty("swt.autoScale.method", "nearest");
-        // Edge 浏览器 Hi-DPI 支持
+        // Edge 浏览器，别用 IE
         System.setProperty("org.eclipse.swt.browser.DefaultType", "edge");
     }
 
@@ -65,12 +67,15 @@ public final class SwtBrowserCanvas extends Canvas {
                     if (input != null) {
                         this.browser.setText(new String(input.readAllBytes(), StandardCharsets.UTF_8));
                     }
-                } catch (Exception ignored) {
+                } catch (Exception e) {
+                    log.debug("Cannot load placeholder.html", e);
                 }
                 this.browserInitialized = true;
                 // 应用正确的大小
                 updateBrowserSize();
-            } catch (SWTError ignored) {
+            } catch (SWTError e) {
+                this.browserInitialized = false;
+                log.debug("Cannot init SWT Browser", e);
             }
         });
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/gui/impl/swing/mainwindow/component/swtembed/SwtBrowserCanvas.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/gui/impl/swing/mainwindow/component/swtembed/SwtBrowserCanvas.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.gui.impl.swing.mainwindow.component.swtembed;
 
 import com.ghostchu.peerbanhelper.Main;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.SWTError;
 import org.eclipse.swt.awt.SWT_AWT;
 import org.eclipse.swt.browser.Browser;
 import org.eclipse.swt.widgets.Display;
@@ -57,17 +58,20 @@ public final class SwtBrowserCanvas extends Canvas {
             // 计算 DPI 缩放比例
             calculateDPIScaleFactor();
             this.shell = SWT_AWT.new_Shell(display, this);
-            this.browser = new Browser(this.shell, SWT.NONE);
-            this.browser.setVisible(true);
-            try (var input = Main.class.getResourceAsStream("/placeholder.html")) {
-                if (input != null) {
-                    this.browser.setText(new String(input.readAllBytes(), StandardCharsets.UTF_8));
+            try {
+                this.browser = new Browser(this.shell, SWT.NONE);
+                this.browser.setVisible(true);
+                try (var input = Main.class.getResourceAsStream("/placeholder.html")) {
+                    if (input != null) {
+                        this.browser.setText(new String(input.readAllBytes(), StandardCharsets.UTF_8));
+                    }
+                } catch (Exception ignored) {
                 }
-            } catch (Exception ignored) {
+                this.browserInitialized = true;
+                // 应用正确的大小
+                updateBrowserSize();
+            } catch (SWTError ignored) {
             }
-            this.browserInitialized = true;
-            // 应用正确的大小
-            updateBrowserSize();
         });
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/monitor/SwarmTrackingModule.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/monitor/SwarmTrackingModule.java
@@ -119,6 +119,7 @@ public final class SwarmTrackingModule extends AbstractFeatureModule implements 
                             peer.getPeerAddress().getPort(),
                             torrent.getHash(),
                             torrent.isPrivate(),
+                            torrent.getSize(),
                             downloader.getId(),
                             torrent.getProgress(),
                             peer.getPeerId(),

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -41,7 +41,9 @@ public final class IPAddressUtil {
             return ipAddress;
         } catch (AddressStringException e) {
             log.error("Unable to get ipaddress from ip {}", ipFinal, e);
-            assert false;
+            return INVALID_ADDRESS_MISSINGNO;
+        } catch (Exception e) {
+            log.error("Unable to get ipaddress from ip {} because an unknown error, returning default.", ipFinal, e);
             return INVALID_ADDRESS_MISSINGNO;
         }
     }

--- a/src/main/resources/META-INF/spring.factories
+++ b/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,2 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-  com.ghostchu.peerbanhelper.configuration.Pf4jConfiguration
+  com.ghostchu.peerbanhelper.configuration.pf4j.Pf4jConfiguration


### PR DESCRIPTION
## 错误修复

* 修复当 Microsoft Edge WebView2 不存在或被用户删除时，Swing UI 可能卡死无响应的问题 @paulzzh 
 * Microsoft Edge 是重要系统组件，不建议对其删除
 * 如果确需删除 Edge 浏览器，请考虑保留 Edge WebView2 组件
 * 如果确实需要删除 Edge WebView2，也请不要粉碎目录，而是正常卸载。残留的注册表键可能导致非预期问题
* 修复解析 IPAddress 时如果因各种原因传入非预期参数将可能导致执行中断的问题 @Ghost-chu 
* 修复 Swarm Tracking 中 torrentSize 字段丢失的问题 @Ghost-chu 
* 修复 PeerBanHelper PF4J 插件加载失败时，出现的错误会直接阻止 PeerBanHelper 初始化和启动的问题 @Ghost-chu
* 修复启动时部分情况下 BanList 出现死锁的问题 @Ghost-chu 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 新功能
  - 引入可热插拔插件管理（含 Spring 集成），支持加载/启停插件
  - 群体跟踪新增种子体积记录，便于统计与展示
- 性能与稳定性
  - 启动时预载封禁列表，白名单解禁改为批量处理，降低卡顿
  - 提升 SWT 内嵌浏览器初始化稳定性
  - IP 解析异常提供安全回退，减少崩溃
- 依赖
  - 更新 peerbanhelper 至 9.0.4

<!-- end of auto-generated comment: release notes by coderabbit.ai -->