### PR TITLE
fix(build): use `gradlew` instead of `mvn`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -11,4 +11,4 @@ cd ${current_wd}
 cp -r webui/dist ${static_dir}
 
 echo "Prepare to build jar.."
-mvn -B clean package --file pom.xml
+./gradlew clean build --no-daemon


### PR DESCRIPTION
目前项目使用`gradlew`代替了`mvn`，但是`build.sh`仍然沿用`mvn`，导致无法构建。因此或许应该更新一下构建脚本。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Chores**
  * 更新构建系统配置，优化构建过程。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->