### PR TITLE
修改配置页面查看 BTN 文档提示文本

### DIFF
--- a/webui/src/views/settings/components/config/locale/en-US.ts
+++ b/webui/src/views/settings/components/config/locale/en-US.ts
@@ -69,7 +69,7 @@ export default {
     'Are you sure you want to enable submit?',
   'page.settings.tab.config.btn.allowScript': 'Allow BTN server push scripts',
   'page.settings.tab.config.btn.allowScript.warning':
-    'Warning: this means that the remote server can execute any code on your device, please enable with caution!',
+    'Warning: This means that the remote server can execute any code on your device, please enable with caution!',
   'page.settings.tab.config.btn.allowScript.tips':
     'This option will allow BTN server push scripts to your device, this may increase the accuracy of the ban',
 


### PR DESCRIPTION
移除文档提示中的“(Chinese only)”

修改后的效果如下图：
<img width="1847" height="691" alt="image" src="https://github.com/user-attachments/assets/8bee978b-a755-4420-8a84-db713401ee98" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 优化了设置页面中文档按钮的标签文本，移除“仅限中文”之类的限定说明，使表述更清晰统一。
  * 调整了允许脚本相关的警告文案，修正首字母大写，提高可读性并强化风险提示。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->