### PR TITLE
更新英文提示内容

### DIFF
--- a/webui/src/views/settings/components/config/locale/en-US.ts
+++ b/webui/src/views/settings/components/config/locale/en-US.ts
@@ -58,7 +58,7 @@ export default {
     'The host part of IP address will be set to 0 with this length, and generate corresponding CIDR expression (0-128)',
 
   'page.settings.tab.config.btn.enable': 'Enable BTN',
-  'page.settings.tab.config.btn.doc': 'Read the document first(Chinese only):',
+  'page.settings.tab.config.btn.doc': 'Read the document first:',
   'page.settings.tab.config.btn.enableSubmit': 'Enable submit',
   'page.settings.tab.config.btn.enableSubmit.modal.title': 'Warning',
   'page.settings.tab.config.btn.enableSubmit.modal.content':
@@ -69,7 +69,7 @@ export default {
     'Are you sure you want to enable submit?',
   'page.settings.tab.config.btn.allowScript': 'Allow BTN server push scripts',
   'page.settings.tab.config.btn.allowScript.warning':
-    'Warning: this means that the remote server can execute any code on your device, please enable with caution!',
+    'Warning: This means that the remote server can execute any code on your device, please enable with caution!',
   'page.settings.tab.config.btn.allowScript.tips':
     'This option will allow BTN server push scripts to your device, this may increase the accuracy of the ban',
 


### PR DESCRIPTION
移除文档链接中的 `(Chinese only)`，并优化警告的首字母大写格式

修改后的效果如下图：
<img width="1842" height="679" alt="image" src="https://github.com/user-attachments/assets/49b32942-9f04-4b07-b620-375307e5db27" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发布说明

* **Bug Fixes**
  * 修复警告消息的首字母大小写。
  * 更新文档链接的本地化字符串，移除语言限制说明。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->