### PR TITLE
fix(log): 替换 configBtnNetwork 的请求异常时的日志占位符

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/btn/BtnNetwork.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/btn/BtnNetwork.java
@@ -94,6 +94,7 @@ public final class BtnNetwork implements Reloadable {
     private boolean enabled;
     private String powCaptchaEndpoint;
     private long nextConfigAttemptTime = 0;
+    private final long RETRY_PERIOD_SECONDS = 600;
 
     public BtnNetwork(ScriptEngineManager scriptEngineManager, ModuleMatchCache moduleMatchCache, DownloaderServer downloaderServer, HTTPUtil httpUtil,
                       MetadataService metadataDao, HistoryService historyDao, TrackedSwarmService trackedSwarmDao, SystemInfo systemInfo, TorrentService torrentService,
@@ -157,7 +158,7 @@ public final class BtnNetwork implements Reloadable {
         }
         if (enabled) {
             scheduler = Executors.newScheduledThreadPool(2);
-            scheduler.scheduleWithFixedDelay(this::checkIfNeedRetryConfig, 0, 600, TimeUnit.SECONDS);
+            scheduler.scheduleWithFixedDelay(this::checkIfNeedRetryConfig, 0, RETRY_PERIOD_SECONDS, TimeUnit.SECONDS);
         } else {
             scheduler = null;
         }
@@ -175,7 +176,7 @@ public final class BtnNetwork implements Reloadable {
                 statusCode = resp.code();
                 response = resp.body().string();
                 if (!resp.isSuccessful()) {
-                    log.error(tlUI(Lang.BTN_CONFIG_FAILS, statusCode + " - " + response, 600));
+                    log.error(tlUI(Lang.BTN_CONFIG_FAILS, statusCode + " - " + response, RETRY_PERIOD_SECONDS));
                     configResult = new TranslationComponent(Lang.BTN_CONFIG_STATUS_UNSUCCESSFUL_HTTP_REQUEST, configUrl, statusCode, response);
                     return;
                 }
@@ -251,10 +252,10 @@ public final class BtnNetwork implements Reloadable {
                 configSuccess.set(true);
                 configResult = new TranslationComponent(Lang.BTN_CONFIG_STATUS_SUCCESSFUL);
             } catch (Throwable e) {
-                log.error(tlUI(Lang.BTN_CONFIG_FAILS, e.getMessage(), 600), e);
+                log.error(tlUI(Lang.BTN_CONFIG_FAILS, e.getMessage(), RETRY_PERIOD_SECONDS), e);
                 configResult = new TranslationComponent(Lang.BTN_CONFIG_STATUS_EXCEPTION, e.getClass().getName(), e.getMessage());
                 configSuccess.set(false);
-                nextConfigAttemptTime = System.currentTimeMillis() + 600 * 1000;
+                nextConfigAttemptTime = System.currentTimeMillis() + RETRY_PERIOD_SECONDS * 1000;
                 Sentry.captureException(e);
             }
         })).join();


### PR DESCRIPTION
修复异常情况下的日志占位符缺少实际值
<img width="1189" height="251" alt="image" src="https://github.com/user-attachments/assets/56f247e3-f2cc-43f6-a279-ff38a76ba561" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **优化改进**
  * 将重试间隔统一为可重用常量，替换了之前的硬编码值，提升维护性。
  * 调度重试和错误日志中均使用一致的重试周期，确保重试行为和诊断信息一致。
  * 改进了下一次配置重试时间的计算与记录，增强故障排查可靠性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->