### PR TITLE
fix(check_java): pause for error log

### DIFF
--- a/pkg/portable/check_java.bat
+++ b/pkg/portable/check_java.bat
@@ -29,8 +29,7 @@ if exist "%~dp0jre\bin\java.exe" (
     ) else (
         echo %MSG_INVALID_JAVA_HOME%
         echo [Error] JAVA_HOME = "%JAVA_HOME%"
-        pause
-        exit /b 1
+        pause & exit /b 1
     )
 ) else (
     for /f "delims=" %%i in ('where.exe java.exe 2^>nul') do (
@@ -42,8 +41,7 @@ if exist "%~dp0jre\bin\java.exe" (
     :: No Java in PATH
     echo %MSG_NOT_FOUND_1%
     echo %MSG_NOT_FOUND_2%
-    pause
-    exit /b 1
+    pause & exit /b 1
 )
 
 :CHECK_VER
@@ -74,8 +72,7 @@ setlocal enabledelayedexpansion
 set "MSG_VERSION_LOW_DISPLAY=!MSG_VERSION_LOW:{VER}=%MAJOR_VER%!"
 if !MAJOR_VER! LSS %REQ_VER% (
     echo !MSG_VERSION_LOW_DISPLAY!
-    pause
-    exit /b 1
+    pause & exit /b 1
 )
 endlocal
 
@@ -84,5 +81,4 @@ exit /b 0
 
 :ERROR_PARSE
 echo %MSG_PARSE_FAILED%
-pause
-exit /b 1
+pause & exit /b 1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 当检测到 JAVA_HOME 无效、系统中找不到 Java、Java 版本低于要求或版本解析失败等错误时，脚本在退出前会暂停，便于用户查看错误提示。
  * 正常运行路径未改变，仅错误终止流程新增暂停以提高可见性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->