### PR TITLE
Native MTR 支持

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/Main.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/Main.java
@@ -246,6 +246,8 @@ public class Main {
         String os = System.getProperty("os.name").toLowerCase(Locale.ROOT);
         if (os.startsWith("win")) {
             platform = new WindowsPlatform();
+        } else if (os.startsWith("linux") || os.startsWith("mac")) {
+            platform = new com.ghostchu.peerbanhelper.platform.impl.posix.PosixPlatform();
         } else {
             platform = null;
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/PeerBanHelper.java
@@ -17,6 +17,7 @@ import com.ghostchu.peerbanhelper.module.impl.monitor.SessionAnalyseServiceModul
 import com.ghostchu.peerbanhelper.module.impl.monitor.SwarmTrackingModule;
 import com.ghostchu.peerbanhelper.module.impl.rule.*;
 import com.ghostchu.peerbanhelper.module.impl.webapi.*;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrOptions;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
 import com.ghostchu.peerbanhelper.util.CommonUtil;
@@ -166,6 +167,11 @@ public class PeerBanHelper implements Reloadable {
             return;
         }
         ExchangeMap.GUI_DISPLAY_FLAGS.add(new ExchangeMap.DisplayFlag("debug-mode", 20, tlUI(Lang.GUI_TITLE_DEBUG)));
+
+
+        System.out.println("MTR Supported: " + Main.getPlatform().getMtrTool().isSupported(InetAddress.ofLiteral("58.216.33.162")));
+       var result = Main.getPlatform().getMtrTool().trace(InetAddress.ofLiteral("58.216.33.162"), MtrOptions.defaults());
+       System.out.println(result);
     }
 
 

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/Platform.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/Platform.java
@@ -2,9 +2,16 @@ package com.ghostchu.peerbanhelper.platform;
 
 import com.ghostchu.peerbanhelper.platform.types.EcoQosAPI;
 import com.ghostchu.peerbanhelper.platform.types.MalwareScanner;
+import com.ghostchu.peerbanhelper.platform.types.MtrTool;
 import org.jetbrains.annotations.Nullable;
 
 public interface Platform {
     @Nullable EcoQosAPI getEcoQosAPI();
     @Nullable MalwareScanner getMalwareScanner();
+
+    /**
+     * Returns a platform-specific MTR (My Traceroute) tool, or {@code null} if
+     * ICMP tracing is not available on this platform / with the current privileges.
+     */
+    @Nullable MtrTool getMtrTool();
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/PosixPlatform.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/PosixPlatform.java
@@ -1,0 +1,54 @@
+package com.ghostchu.peerbanhelper.platform.impl.posix;
+
+import com.ghostchu.peerbanhelper.platform.Platform;
+import com.ghostchu.peerbanhelper.platform.impl.posix.mtr.PosixMtrTool;
+import com.ghostchu.peerbanhelper.platform.types.EcoQosAPI;
+import com.ghostchu.peerbanhelper.platform.types.MalwareScanner;
+import com.ghostchu.peerbanhelper.platform.types.MtrTool;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * {@link Platform} implementation for Linux and macOS.
+ *
+ * <p>Currently provides:
+ * <ul>
+ *   <li>{@link MtrTool} via {@link PosixMtrTool} (ICMP, with automatic
+ *       privilege-level detection)</li>
+ *   <li>EcoQosAPI: not available (Windows-only)</li>
+ *   <li>MalwareScanner: not available (Windows-only)</li>
+ * </ul>
+ */
+@Slf4j
+public class PosixPlatform implements Platform {
+
+    @Nullable
+    private final MtrTool mtrTool;
+
+    public PosixPlatform() {
+        MtrTool tool = null;
+        try {
+            tool = new PosixMtrTool();
+        } catch (Exception e) {
+            log.debug("PosixMtrTool initialisation failed – MTR not available: {}", e.getMessage());
+        }
+        this.mtrTool = tool;
+    }
+
+    @Override
+    public @Nullable EcoQosAPI getEcoQosAPI() {
+        return null; // Windows-only
+    }
+
+    @Override
+    public @Nullable MalwareScanner getMalwareScanner() {
+        return null; // Windows-only
+    }
+
+    @Override
+    public @Nullable MtrTool getMtrTool() {
+        return mtrTool;
+    }
+}
+
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/LibcSocket.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/LibcSocket.java
@@ -1,0 +1,373 @@
+package com.ghostchu.peerbanhelper.platform.impl.posix.mtr;
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.util.Optional;
+
+/**
+ * FFM bindings for the POSIX libc socket API required for ICMP tracing.
+ *
+ * <p>All symbols are looked up through {@code Linker.nativeLinker().defaultLookup()}
+ * so no explicit library name is needed (works on both Linux and macOS).
+ *
+ * <h3>Socket creation strategy</h3>
+ * <ol>
+ *   <li>Try {@code SOCK_DGRAM + IPPROTO_ICMP} (unprivileged on Linux ≥ 3.x with
+ *       the correct {@code net.ipv4.ping_group_range} sysctl, and on macOS).</li>
+ *   <li>If {@code socket()} returns {@code -1} with errno {@code EPERM} or
+ *       {@code EACCES}, fall back to {@code SOCK_RAW + IPPROTO_ICMP} (requires
+ *       {@code CAP_NET_RAW} or root).</li>
+ *   <li>If that also fails, throw
+ *       {@link com.ghostchu.peerbanhelper.platform.mtr.exception.MtrPermissionException}.</li>
+ * </ol>
+ */
+public final class LibcSocket {
+
+    // -------------------------------------------------------------------------
+    // Linker / symbol lookup
+    // -------------------------------------------------------------------------
+
+    private static final Linker       LINKER  = Linker.nativeLinker();
+    private static final SymbolLookup LOOKUP  = LINKER.defaultLookup();
+
+    // =========================================================================
+    // int socket(int domain, int type, int protocol)
+    // =========================================================================
+
+    private static final MethodHandle MH_SOCKET = LINKER.downcallHandle(
+            LOOKUP.find("socket").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,   // domain
+                    ValueLayout.JAVA_INT,   // type
+                    ValueLayout.JAVA_INT)   // protocol
+    );
+
+    // =========================================================================
+    // int close(int fd)
+    // =========================================================================
+
+    private static final MethodHandle MH_CLOSE = LINKER.downcallHandle(
+            LOOKUP.find("close").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT)   // fd
+    );
+
+    // =========================================================================
+    // int setsockopt(int sockfd, int level, int optname,
+    //                const void *optval, socklen_t optlen)
+    // =========================================================================
+
+    private static final MethodHandle MH_SETSOCKOPT = LINKER.downcallHandle(
+            LOOKUP.find("setsockopt").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,   // sockfd
+                    ValueLayout.JAVA_INT,   // level
+                    ValueLayout.JAVA_INT,   // optname
+                    ValueLayout.ADDRESS,    // optval
+                    ValueLayout.JAVA_INT)   // optlen
+    );
+
+    // =========================================================================
+    // ssize_t sendto(int sockfd, const void *buf, size_t len, int flags,
+    //                const struct sockaddr *dest_addr, socklen_t addrlen)
+    // =========================================================================
+
+    private static final MethodHandle MH_SENDTO = LINKER.downcallHandle(
+            LOOKUP.find("sendto").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG,  // ssize_t
+                    ValueLayout.JAVA_INT,   // sockfd
+                    ValueLayout.ADDRESS,    // buf
+                    ValueLayout.JAVA_LONG,  // len (size_t)
+                    ValueLayout.JAVA_INT,   // flags
+                    ValueLayout.ADDRESS,    // dest_addr
+                    ValueLayout.JAVA_INT)   // addrlen
+    );
+
+    // =========================================================================
+    // ssize_t recvfrom(int sockfd, void *buf, size_t len, int flags,
+    //                  struct sockaddr *src_addr, socklen_t *addrlen)
+    // =========================================================================
+
+    private static final MethodHandle MH_RECVFROM = LINKER.downcallHandle(
+            LOOKUP.find("recvfrom").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_LONG,  // ssize_t
+                    ValueLayout.JAVA_INT,   // sockfd
+                    ValueLayout.ADDRESS,    // buf
+                    ValueLayout.JAVA_LONG,  // len (size_t)
+                    ValueLayout.JAVA_INT,   // flags
+                    ValueLayout.ADDRESS,    // src_addr
+                    ValueLayout.ADDRESS)    // addrlen (socklen_t*)
+    );
+
+    // =========================================================================
+    // int bind(int sockfd, const struct sockaddr *addr, socklen_t addrlen)
+    // =========================================================================
+
+    private static final MethodHandle MH_BIND = LINKER.downcallHandle(
+            LOOKUP.find("bind").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS,
+                    ValueLayout.JAVA_INT)
+    );
+
+    // =========================================================================
+    // int select(int nfds, fd_set *readfds, fd_set *writefds,
+    //            fd_set *exceptfds, struct timeval *timeout)
+    // =========================================================================
+
+    private static final MethodHandle MH_SELECT = LINKER.downcallHandle(
+            LOOKUP.find("select").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.JAVA_INT,   // nfds
+                    ValueLayout.ADDRESS,    // readfds
+                    ValueLayout.ADDRESS,    // writefds
+                    ValueLayout.ADDRESS,    // exceptfds
+                    ValueLayout.ADDRESS)    // timeout
+    );
+
+    // =========================================================================
+    // errno access
+    // =========================================================================
+
+    /**
+     * On Linux errno is accessed through a thread-local pointer returned by
+     * {@code __errno_location()}; on macOS via {@code __error()}.  Both return
+     * {@code int*}.
+     */
+    private static final MethodHandle MH_ERRNO_LOCATION;
+
+    static {
+        Optional<MemorySegment> errnoSym = LOOKUP.find("__errno_location"); // Linux
+        if (errnoSym.isEmpty()) {
+            errnoSym = LOOKUP.find("__error"); // macOS
+        }
+        if (errnoSym.isPresent()) {
+            MH_ERRNO_LOCATION = LINKER.downcallHandle(
+                    errnoSym.get(),
+                    FunctionDescriptor.of(ValueLayout.ADDRESS) // int*
+            );
+        } else {
+            MH_ERRNO_LOCATION = null; // should not happen on Linux/macOS
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Private constructor
+    // -------------------------------------------------------------------------
+
+    private LibcSocket() {}
+
+    // =========================================================================
+    // Public wrappers
+    // =========================================================================
+
+    /**
+     * Creates a socket.
+     *
+     * @return file descriptor (≥ 0) on success, {@code -1} on error (check errno)
+     */
+    public static int socket(int domain, int type, int protocol) {
+        try {
+            return (int) MH_SOCKET.invokeExact(domain, type, protocol);
+        } catch (Throwable t) {
+            throw new RuntimeException("socket() failed", t);
+        }
+    }
+
+    /**
+     * Closes a socket file descriptor.
+     *
+     * @return {@code 0} on success, {@code -1} on error
+     */
+    public static int close(int fd) {
+        try {
+            return (int) MH_CLOSE.invokeExact(fd);
+        } catch (Throwable t) {
+            throw new RuntimeException("close() failed", t);
+        }
+    }
+
+    /**
+     * Sets a socket option.
+     *
+     * @param optval  pre-allocated segment holding the option value
+     * @param optlen  byte length of optval
+     * @return {@code 0} on success, {@code -1} on error
+     */
+    public static int setsockopt(int fd, int level, int optname,
+                                 MemorySegment optval, int optlen) {
+        try {
+            return (int) MH_SETSOCKOPT.invokeExact(fd, level, optname, optval, optlen);
+        } catch (Throwable t) {
+            throw new RuntimeException("setsockopt() failed", t);
+        }
+    }
+
+    /**
+     * Sends a datagram.
+     *
+     * @param buf      payload segment
+     * @param len      number of bytes to send
+     * @param flags    send flags (normally 0)
+     * @param destAddr destination sockaddr
+     * @param addrLen  byte length of destAddr
+     * @return bytes sent, or {@code -1} on error
+     */
+    public static long sendto(int fd, MemorySegment buf, long len, int flags,
+                              MemorySegment destAddr, int addrLen) {
+        try {
+            return (long) MH_SENDTO.invokeExact(fd, buf, len, flags, destAddr, addrLen);
+        } catch (Throwable t) {
+            throw new RuntimeException("sendto() failed", t);
+        }
+    }
+
+    /**
+     * Receives a datagram.
+     *
+     * @param buf       receive buffer
+     * @param len       buffer capacity
+     * @param flags     receive flags (normally 0)
+     * @param srcAddr   output sockaddr (may be {@link MemorySegment#NULL})
+     * @param addrLenPtr output socklen_t (may be {@link MemorySegment#NULL})
+     * @return bytes received, or {@code -1} on error
+     */
+    public static long recvfrom(int fd, MemorySegment buf, long len, int flags,
+                                MemorySegment srcAddr, MemorySegment addrLenPtr) {
+        try {
+            return (long) MH_RECVFROM.invokeExact(fd, buf, len, flags, srcAddr, addrLenPtr);
+        } catch (Throwable t) {
+            throw new RuntimeException("recvfrom() failed", t);
+        }
+    }
+
+    /**
+     * Binds a socket to a local address.
+     *
+     * @return {@code 0} on success, {@code -1} on error
+     */
+    public static int bind(int fd, MemorySegment addr, int addrLen) {
+        try {
+            return (int) MH_BIND.invokeExact(fd, addr, addrLen);
+        } catch (Throwable t) {
+            throw new RuntimeException("bind() failed", t);
+        }
+    }
+
+    /**
+     * Waits until {@code fd} becomes readable or timeout expires.
+     *
+     * @param fd        socket file descriptor
+     * @param timeoutUs timeout in microseconds (0 = poll, negative = ignored/use 0)
+     * @return {@code 1} if readable, {@code 0} on timeout, {@code -1} on error
+     */
+    public static int selectReadable(int fd, long timeoutUs) {
+        try (Arena arena = Arena.ofConfined()) {
+            // fd_set: 128 bytes on Linux (1024 bits), 128 bytes on macOS
+            int fdSetBytes = 128;
+            MemorySegment fdSet = arena.allocate(fdSetBytes);
+
+            // FD_ZERO + FD_SET: set bit [fd] in fdSet
+            int wordIndex = fd / 64;
+            long bitMask  = 1L << (fd % 64);
+            if (wordIndex < fdSetBytes / 8) {
+                long current = fdSet.get(ValueLayout.JAVA_LONG, (long) wordIndex * 8);
+                fdSet.set(ValueLayout.JAVA_LONG, (long) wordIndex * 8, current | bitMask);
+            }
+
+            // struct timeval { long tv_sec; long tv_usec; }
+            // On Linux/macOS 64-bit: each field is 8 bytes
+            MemorySegment tv = arena.allocate(16); // 8 + 8
+            long secs  = timeoutUs / 1_000_000L;
+            long usecs = timeoutUs % 1_000_000L;
+            tv.set(ValueLayout.JAVA_LONG, 0, secs);
+            tv.set(ValueLayout.JAVA_LONG, 8, usecs);
+
+            return (int) MH_SELECT.invokeExact(fd + 1, fdSet, MemorySegment.NULL,
+                                               MemorySegment.NULL, tv);
+        } catch (Throwable t) {
+            throw new RuntimeException("select() failed", t);
+        }
+    }
+
+    /**
+     * Reads the current value of {@code errno} for the calling thread.
+     *
+     * @return errno value, or {@code -1} if errno location is unavailable
+     */
+    public static int errno() {
+        if (MH_ERRNO_LOCATION == null) return -1;
+        try {
+            MemorySegment ptr = (MemorySegment) MH_ERRNO_LOCATION.invokeExact();
+            if (ptr.equals(MemorySegment.NULL)) return -1;
+            // Reinterpret as a single int (errno is an int)
+            return ptr.reinterpret(4).get(ValueLayout.JAVA_INT, 0);
+        } catch (Throwable t) {
+            return -1;
+        }
+    }
+
+    // =========================================================================
+    // Constants (not platform-dependent for our use-cases)
+    // =========================================================================
+
+    /** Address family: IPv4. */
+    public static final int AF_INET    = 2;
+    /** Address family: IPv6. */
+    public static final int AF_INET6   = 10; // Linux; overridden for macOS at runtime
+
+    /** Socket type: raw (requires privileges). */
+    public static final int SOCK_RAW   = 3;
+    /** Socket type: datagram (unprivileged ICMP on Linux/macOS). */
+    public static final int SOCK_DGRAM = 2;
+
+    /** IP protocol: ICMPv4. */
+    public static final int IPPROTO_ICMP   = 1;
+    /** IP protocol: ICMPv6. */
+    public static final int IPPROTO_ICMPV6 = 58;
+
+    /** SOL_SOCKET level. */
+    public static final int SOL_SOCKET      = 1;
+    /** IPPROTO_IP level. */
+    public static final int IPPROTO_IP      = 0;
+
+    /* ----- IP_* socket options ----- */
+    /** IP_TTL (Linux/macOS). */
+    public static final int IP_TTL          = 2;
+    /** IP_TOS (Linux). */
+    public static final int IP_TOS          = 1;
+    /** IPV6_UNICAST_HOPS. */
+    public static final int IPV6_UNICAST_HOPS = 16;
+    /** IPV6_TCLASS (Linux). */
+    public static final int IPV6_TCLASS     = 67;
+
+    /** SO_RCVTIMEO – receive timeout. */
+    public static final int SO_RCVTIMEO     = 20; // Linux; 20 for macOS too
+
+    /** errno: Operation not permitted. */
+    public static final int EPERM  = 1;
+    /** errno: Permission denied. */
+    public static final int EACCES = 13;
+    /** errno: Would block / timed out (non-blocking or SO_RCVTIMEO). */
+    public static final int EAGAIN  = 11;
+    public static final int EWOULDBLOCK = 11;
+
+    /** sizeof(struct sockaddr_in)  = 16 bytes. */
+    public static final int SOCKADDR_IN_SIZE  = 16;
+    /** sizeof(struct sockaddr_in6) = 28 bytes. */
+    public static final int SOCKADDR_IN6_SIZE = 28;
+
+    // sockaddr_in offsets
+    public static final int SA_OFFSET_FAMILY = 0;  // 2 bytes
+    public static final int SA_OFFSET_PORT   = 2;  // 2 bytes
+    public static final int SA_OFFSET_ADDR   = 4;  // 4 bytes
+
+    // sockaddr_in6 offsets
+    public static final int SA6_OFFSET_FAMILY   = 0;   // 2 bytes
+    public static final int SA6_OFFSET_PORT     = 2;   // 2 bytes
+    public static final int SA6_OFFSET_FLOWINFO = 4;   // 4 bytes
+    public static final int SA6_OFFSET_ADDR     = 8;   // 16 bytes
+    public static final int SA6_OFFSET_SCOPE_ID = 24;  // 4 bytes
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/PosixMtrTool.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/PosixMtrTool.java
@@ -1,0 +1,715 @@
+package com.ghostchu.peerbanhelper.platform.impl.posix.mtr;
+
+import com.ghostchu.peerbanhelper.platform.mtr.MtrHop;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrOptions;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrResult;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrException;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrPermissionException;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrTimeoutException;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrUnsupportedException;
+import com.ghostchu.peerbanhelper.platform.types.MtrTool;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * POSIX (Linux / macOS) implementation of {@link MtrTool} using raw ICMP sockets
+ * via the Foreign Function & Memory API.
+ *
+ * <h3>Socket creation strategy</h3>
+ * <ol>
+ *   <li>Try {@code SOCK_DGRAM + IPPROTO_ICMP(V6)} – works without root on Linux
+ *       (if {@code net.ipv4.ping_group_range} allows the current GID) and macOS.</li>
+ *   <li>On {@code EPERM} / {@code EACCES}, try {@code SOCK_RAW + IPPROTO_ICMP(V6)}.</li>
+ *   <li>If that also fails, throw {@link MtrPermissionException}.</li>
+ * </ol>
+ *
+ * <h3>IPv6 / macOS caveat</h3>
+ * macOS supports {@code SOCK_DGRAM + IPPROTO_ICMPV6} only for link-local or with
+ * root.  When the DGRAM approach fails for IPv6 on macOS, we automatically retry
+ * with {@code SOCK_RAW}.
+ *
+ * <h3>Concurrency</h3>
+ * All TTL levels are probed in parallel using virtual threads.  Within each TTL,
+ * probes are sent sequentially and retried up to {@link MtrOptions#getRetryCount()}
+ * times on timeout before being marked as lost.
+ *
+ * <h3>Identifier disambiguation</h3>
+ * Each {@link PosixMtrTool} instance uses a random 16-bit {@code identifier}
+ * embedded in the ICMP echo header so that concurrent instances (or external ping
+ * processes) do not interfere with each other.
+ */
+@Slf4j
+public final class PosixMtrTool implements MtrTool {
+
+    // -------------------------------------------------------------------------
+    // Instance state
+    // -------------------------------------------------------------------------
+
+    /** Mode used to open the IPv4 socket (null if IPv4 is unavailable). */
+    @Nullable private final PosixSocketMode mode4;
+    /** Mode used to open the IPv6 socket (null if IPv6 is unavailable). */
+    @Nullable private final PosixSocketMode mode6;
+
+    /** Reason IPv4 is unavailable, if any. */
+    @Nullable private final String unavailReason4;
+    /** Reason IPv6 is unavailable, if any. */
+    @Nullable private final String unavailReason6;
+
+    /**
+     * Per-instance unique identifier (16-bit) for ICMP echo frames.
+     * Avoids mixing up replies with other probing processes.
+     */
+    private final int identifier;
+
+    /** Sequence counter – incremented per probe send. */
+    private final AtomicInteger seqCounter = new AtomicInteger(0);
+
+    /** Whether we are running on macOS (affects AF_INET6 constant). */
+    private final boolean isMacOs;
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    /**
+     * Creates a new {@link PosixMtrTool}, probing socket availability for both
+     * IPv4 and IPv6.
+     *
+     * <p>This constructor does <em>not</em> throw – unavailability of one or both
+     * address families is recorded internally and surfaced via
+     * {@link #isSupported(InetAddress)}.
+     */
+    public PosixMtrTool() {
+        this.identifier = ThreadLocalRandom.current().nextInt(1, 0xFFFF);
+        String osName = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
+        this.isMacOs  = osName.contains("mac");
+
+        // Probe IPv4
+        SocketProbeResult r4 = probeSocketAvailability(false);
+        this.mode4          = r4.mode;
+        this.unavailReason4 = r4.errorReason;
+        if (r4.mode != null) {
+            log.debug("MTR IPv4 socket mode: {}", r4.mode);
+        } else {
+            log.debug("MTR IPv4 not available: {}", r4.errorReason);
+        }
+
+        // Probe IPv6
+        SocketProbeResult r6 = probeSocketAvailability(true);
+        this.mode6          = r6.mode;
+        this.unavailReason6 = r6.errorReason;
+        if (r6.mode != null) {
+            log.debug("MTR IPv6 socket mode: {}", r6.mode);
+        } else {
+            log.debug("MTR IPv6 not available: {}", r6.errorReason);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MtrTool interface
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean isSupported(@NotNull InetAddress target) {
+        if (target instanceof Inet4Address) return mode4 != null;
+        if (target instanceof Inet6Address) return mode6 != null;
+        return false;
+    }
+
+    @Override
+    public @NotNull MtrResult trace(@NotNull InetAddress target, @NotNull MtrOptions options)
+            throws MtrException {
+
+        boolean isV6 = target instanceof Inet6Address;
+        PosixSocketMode mode = isV6 ? mode6 : mode4;
+        String unavailReason = isV6 ? unavailReason6 : unavailReason4;
+
+        if (mode == null) {
+            // Determine the right exception type
+            if (unavailReason != null && unavailReason.contains("errno=" + LibcSocket.EPERM)
+                    || unavailReason != null && unavailReason.contains("errno=" + LibcSocket.EACCES)) {
+                throw new MtrPermissionException(
+                        "Insufficient privileges to open ICMP socket: " + unavailReason,
+                        LibcSocket.EPERM);
+            }
+            throw new MtrUnsupportedException(
+                    "ICMP socket not available for "
+                    + (isV6 ? "IPv6" : "IPv4") + ": " + unavailReason);
+        }
+
+        Instant start = Instant.now();
+        byte[] payload = buildPayload(options.getPayloadSize());
+
+        // Launch all TTL probes in parallel using virtual threads
+        List<Future<MtrHop>> futures = new ArrayList<>(options.getMaxHops());
+        long totalMs = options.getTotalTimeout().toMillis();
+
+        try (ExecutorService exec = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int ttl = 1; ttl <= options.getMaxHops(); ttl++) {
+                final int currentTtl = ttl;
+                futures.add(exec.submit(
+                        () -> probeHop(target, currentTtl, payload, options, isV6, mode)));
+            }
+            exec.shutdown();
+            try {
+                if (!exec.awaitTermination(totalMs, TimeUnit.MILLISECONDS)) {
+                    exec.shutdownNow();
+                    throw new MtrTimeoutException(
+                            "Total trace timeout exceeded (" + options.getTotalTimeout() + ")");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MtrException("Trace interrupted", e);
+            }
+        }
+
+        // Collect results in TTL order, stopping at destination
+        List<MtrHop> hops = new ArrayList<>(options.getMaxHops());
+        for (int i = 0; i < options.getMaxHops(); i++) {
+            MtrHop hop;
+            try {
+                hop = futures.get(i).get();
+            } catch (ExecutionException e) {
+                log.debug("TTL={} threw: {}", i + 1, e.getCause().getMessage());
+                hop = unresponsiveHop(i + 1, options.getProbeCount());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MtrException("Interrupted collecting hop " + (i + 1), e);
+            } catch (CancellationException e) {
+                hop = unresponsiveHop(i + 1, options.getProbeCount());
+            }
+            hops.add(hop);
+
+            // Stop once we've reached the destination
+            if (hop.getAddress() != null && hop.getAddress().equals(target)) {
+                break;
+            }
+        }
+
+        // Optional PTR resolution
+        if (options.isResolveHostnames()) {
+            hops = resolveHostnames(hops);
+        }
+
+        return new MtrResult(target, hops, start, Duration.between(start, Instant.now()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-hop probing
+    // -------------------------------------------------------------------------
+
+    private MtrHop probeHop(InetAddress target, int ttl, byte[] payload,
+                            MtrOptions options, boolean isV6,
+                            PosixSocketMode mode) throws MtrException {
+        List<Duration> rtts = new ArrayList<>(options.getProbeCount());
+        int sent = 0, received = 0;
+        InetAddress replyAddr = null;
+
+        for (int probe = 0; probe < options.getProbeCount(); probe++) {
+            sent++;
+            Duration rtt = null;
+
+            for (int attempt = 0; attempt <= options.getRetryCount(); attempt++) {
+                long attemptTimeoutUs = computeAttemptTimeoutUs(options);
+                ProbeResult res = sendSingleProbe(
+                        target, ttl, payload, attemptTimeoutUs, isV6, mode);
+                if (res != null) {
+                    rtt = res.rtt;
+                    if (replyAddr == null) replyAddr = res.from;
+                    break;
+                }
+                // else: timed out – retry
+            }
+
+            if (rtt != null) {
+                rtts.add(rtt);
+                received++;
+            }
+        }
+
+        return new MtrHop(ttl, replyAddr, null, rtts, sent, received);
+    }
+
+    /**
+     * Per-attempt timeout in microseconds.  Divides the probe budget evenly
+     * across {@code (1 + retryCount)} attempts.
+     */
+    private long computeAttemptTimeoutUs(MtrOptions options) {
+        long budgetUs = options.getProbeTimeout().toNanos() / 1_000L;
+        return Math.max(100_000L, budgetUs / (options.getRetryCount() + 1));
+    }
+
+    // -------------------------------------------------------------------------
+    // Single probe (open socket, set TTL, send, recv)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Opens a fresh socket for each probe so that TTL option can be set cleanly
+     * and so concurrent virtual threads don't share socket state.
+     */
+    @Nullable
+    private ProbeResult sendSingleProbe(InetAddress target, int ttl, byte[] payload,
+                                        long timeoutUs, boolean isV6,
+                                        PosixSocketMode mode) throws MtrException {
+        int af       = isV6 ? getAf6() : LibcSocket.AF_INET;
+        int type     = (mode == PosixSocketMode.DGRAM_UNPRIVILEGED)
+                       ? LibcSocket.SOCK_DGRAM : LibcSocket.SOCK_RAW;
+        int protocol = isV6 ? LibcSocket.IPPROTO_ICMPV6 : LibcSocket.IPPROTO_ICMP;
+
+        int fd = LibcSocket.socket(af, type, protocol);
+        if (fd < 0) {
+            int err = LibcSocket.errno();
+            throw new MtrException(
+                    "socket() failed for probe, errno=" + err + " (af=" + af + ", type=" + type + ")");
+        }
+        try {
+            configureSendSocket(fd, ttl, isV6, timeoutUs);
+            return doSendRecv(fd, target, payload, timeoutUs, isV6, mode);
+        } finally {
+            LibcSocket.close(fd);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Socket configuration
+    // -------------------------------------------------------------------------
+
+    private void configureSendSocket(int fd, int ttl, boolean isV6, long timeoutUs)
+            throws MtrException {
+        if (isV6) {
+            setIntSockOpt(fd, LibcSocket.IPPROTO_ICMPV6, LibcSocket.IPV6_UNICAST_HOPS, ttl);
+        } else {
+            setIntSockOpt(fd, LibcSocket.IPPROTO_IP, LibcSocket.IP_TTL, ttl);
+        }
+
+        // Set SO_RCVTIMEO so recvfrom() returns EAGAIN on timeout
+        try (Arena arena = Arena.ofConfined()) {
+            // struct timeval { long sec; long usec; } – 16 bytes on 64-bit
+            MemorySegment tv = arena.allocate(16);
+            long secs  = timeoutUs / 1_000_000L;
+            long usecs = timeoutUs % 1_000_000L;
+            tv.set(ValueLayout.JAVA_LONG, 0, secs);
+            tv.set(ValueLayout.JAVA_LONG, 8, usecs);
+            int rc = LibcSocket.setsockopt(fd, LibcSocket.SOL_SOCKET,
+                                           LibcSocket.SO_RCVTIMEO, tv, 16);
+            if (rc != 0) {
+                log.debug("setsockopt SO_RCVTIMEO failed, errno={}", LibcSocket.errno());
+            }
+        }
+    }
+
+    private void setIntSockOpt(int fd, int level, int optname, int value)
+            throws MtrException {
+        try (Arena arena = Arena.ofConfined()) {
+            MemorySegment valSeg = arena.allocate(ValueLayout.JAVA_INT);
+            valSeg.set(ValueLayout.JAVA_INT, 0, value);
+            int rc = LibcSocket.setsockopt(fd, level, optname, valSeg,
+                                           (int) ValueLayout.JAVA_INT.byteSize());
+            if (rc != 0) {
+                int err = LibcSocket.errno();
+                throw new MtrException(
+                        "setsockopt(" + level + "," + optname + "=" + value + ") failed, errno=" + err);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Send / receive
+    // -------------------------------------------------------------------------
+
+    @Nullable
+    private ProbeResult doSendRecv(int fd, InetAddress target,
+                                   byte[] payload, long timeoutUs,
+                                   boolean isV6, PosixSocketMode mode)
+            throws MtrException {
+        int seq = seqCounter.incrementAndGet() & 0xFFFF;
+
+        try (Arena arena = Arena.ofConfined()) {
+            // Build ICMP packet
+            byte[] pkt = isV6
+                    ? buildIcmpV6Packet(payload, identifier, seq)
+                    : buildIcmpV4Packet(payload, identifier, seq);
+
+            MemorySegment pktSeg = arena.allocate(pkt.length);
+            MemorySegment.copy(pkt, 0, pktSeg, ValueLayout.JAVA_BYTE, 0, pkt.length);
+
+            // Build destination sockaddr
+            MemorySegment destAddr;
+            int destAddrLen;
+            if (isV6) {
+                destAddr    = buildSockAddrIn6(arena, target.getAddress());
+                destAddrLen = LibcSocket.SOCKADDR_IN6_SIZE;
+            } else {
+                destAddr    = buildSockAddrIn4(arena, target.getAddress());
+                destAddrLen = LibcSocket.SOCKADDR_IN_SIZE;
+            }
+
+            long tSend = System.nanoTime();
+            long sent  = LibcSocket.sendto(fd, pktSeg, pkt.length, 0,
+                                           destAddr, destAddrLen);
+            if (sent < 0) {
+                int err = LibcSocket.errno();
+                throw new MtrException("sendto() failed, errno=" + err);
+            }
+
+            // Wait for reply
+            int ready = LibcSocket.selectReadable(fd, timeoutUs);
+            if (ready <= 0) {
+                return null; // timeout
+            }
+
+            // Receive reply
+            int recvBufSize = 1500;
+            MemorySegment recvBuf = arena.allocate(recvBufSize);
+            MemorySegment srcAddrSeg = arena.allocate(
+                    isV6 ? LibcSocket.SOCKADDR_IN6_SIZE : LibcSocket.SOCKADDR_IN_SIZE);
+            MemorySegment addrLenPtr = arena.allocate(ValueLayout.JAVA_INT);
+            addrLenPtr.set(ValueLayout.JAVA_INT, 0,
+                           isV6 ? LibcSocket.SOCKADDR_IN6_SIZE : LibcSocket.SOCKADDR_IN_SIZE);
+
+            long rcvLen = LibcSocket.recvfrom(
+                    fd, recvBuf, recvBufSize, 0, srcAddrSeg, addrLenPtr);
+            if (rcvLen < 0) {
+                return null; // EAGAIN or error
+            }
+            long tRecv = System.nanoTime();
+
+            // Parse reply and extract source address
+            return parseReply(recvBuf, rcvLen, srcAddrSeg, tRecv - tSend, isV6, mode, identifier, seq);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // ICMP packet builders
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds an ICMPv4 echo-request packet with checksum.
+     * <pre>
+     * byte  0: type (8 = ECHO REQUEST)
+     * byte  1: code (0)
+     * byte  2-3: checksum (ones complement)
+     * byte  4-5: identifier
+     * byte  6-7: sequence
+     * byte  8+:  payload
+     * </pre>
+     */
+    private static byte[] buildIcmpV4Packet(byte[] payload, int id, int seq) {
+        byte[] pkt = new byte[8 + payload.length];
+        pkt[0] = 8;                         // ICMP_ECHO
+        pkt[1] = 0;
+        pkt[2] = 0; pkt[3] = 0;             // checksum placeholder
+        pkt[4] = (byte) (id  >> 8);
+        pkt[5] = (byte)  id;
+        pkt[6] = (byte) (seq >> 8);
+        pkt[7] = (byte)  seq;
+        System.arraycopy(payload, 0, pkt, 8, payload.length);
+        int csum = icmpChecksum(pkt);
+        pkt[2] = (byte) (csum >> 8);
+        pkt[3] = (byte)  csum;
+        return pkt;
+    }
+
+    /**
+     * Builds an ICMPv6 echo-request packet (checksum is computed by kernel for
+     * SOCK_RAW; for SOCK_DGRAM the kernel also fills it in, but we compute it
+     * ourselves for SOCK_RAW to be safe).
+     * <pre>
+     * byte  0: type (128 = ICMPV6_ECHO_REQUEST)
+     * byte  1: code (0)
+     * byte  2-3: checksum (0 – kernel fills for SOCK_DGRAM, we fill for SOCK_RAW)
+     * byte  4-5: identifier
+     * byte  6-7: sequence
+     * byte  8+:  payload
+     * </pre>
+     * For SOCK_RAW the kernel handles the pseudo-header checksum via
+     * IPV6_CHECKSUM socket option; we leave checksum = 0 here and rely on the
+     * kernel to fill it.
+     */
+    private static byte[] buildIcmpV6Packet(byte[] payload, int id, int seq) {
+        byte[] pkt = new byte[8 + payload.length];
+        pkt[0] = (byte) 128;                // ICMPV6_ECHO_REQUEST
+        pkt[1] = 0;
+        pkt[2] = 0; pkt[3] = 0;             // checksum – kernel fills
+        pkt[4] = (byte) (id  >> 8);
+        pkt[5] = (byte)  id;
+        pkt[6] = (byte) (seq >> 8);
+        pkt[7] = (byte)  seq;
+        System.arraycopy(payload, 0, pkt, 8, payload.length);
+        return pkt;
+    }
+
+    /** Standard ICMP ones-complement checksum. */
+    private static int icmpChecksum(byte[] data) {
+        int sum = 0;
+        for (int i = 0; i < data.length - 1; i += 2) {
+            sum += ((data[i] & 0xFF) << 8) | (data[i + 1] & 0xFF);
+        }
+        if ((data.length & 1) == 1) {
+            sum += (data[data.length - 1] & 0xFF) << 8;
+        }
+        while ((sum >> 16) != 0) {
+            sum = (sum & 0xFFFF) + (sum >> 16);
+        }
+        return ~sum & 0xFFFF;
+    }
+
+    // -------------------------------------------------------------------------
+    // Reply parsing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parses the raw bytes received from the socket to extract the source
+     * address and RTT.
+     *
+     * <p>For SOCK_RAW with IPv4: the kernel prepends the 20-byte IP header,
+     * so the ICMP header starts at byte 20.  The ICMP type will be either
+     * 0 (echo reply) or 11 (time exceeded – contains the original IP+ICMP).
+     *
+     * <p>For SOCK_DGRAM with IPv4/IPv6: the kernel strips the IP header and
+     * delivers only the ICMP payload starting from byte 0.
+     */
+    @Nullable
+    private ProbeResult parseReply(MemorySegment buf, long rcvLen,
+                                   MemorySegment srcAddrSeg,
+                                   long elapsedNs,
+                                   boolean isV6, PosixSocketMode mode,
+                                   int expectedId, int expectedSeq)
+            throws MtrException {
+        try {
+            byte[] raw = segmentToBytes(buf, rcvLen);
+
+            // Extract source IP from sockaddr
+            InetAddress from = isV6
+                    ? extractAddrV6(srcAddrSeg)
+                    : extractAddrV4(srcAddrSeg);
+
+            // Locate the ICMP header within the received bytes
+            int icmpOffset;
+            if (!isV6 && mode == PosixSocketMode.RAW_PRIVILEGED) {
+                // IPv4 RAW: kernel delivers IP header + ICMP
+                if (raw.length < 20) return null;
+                icmpOffset = (raw[0] & 0x0F) * 4; // IP header length from IHL field
+            } else {
+                // IPv4 DGRAM or IPv6 (any mode): kernel strips IP header
+                icmpOffset = 0;
+            }
+
+            if (raw.length < icmpOffset + 8) return null;
+
+            int icmpType = raw[icmpOffset] & 0xFF;
+            int icmpCode = raw[icmpOffset + 1] & 0xFF;
+
+            if (isV6) {
+                // ICMPv6 type 129 = echo reply; type 3 = time exceeded
+                if (icmpType == 129) {
+                    // Echo reply – check identifier and sequence
+                    int replyId  = ((raw[icmpOffset + 4] & 0xFF) << 8) | (raw[icmpOffset + 5] & 0xFF);
+                    int replySeq = ((raw[icmpOffset + 6] & 0xFF) << 8) | (raw[icmpOffset + 7] & 0xFF);
+                    if (replyId != expectedId || replySeq != expectedSeq) return null; // not ours
+                    return new ProbeResult(from, Duration.ofNanos(elapsedNs));
+                } else if (icmpType == 3 && icmpCode == 0) {
+                    // Time exceeded (hop limit) – valid intermediate hop
+                    return new ProbeResult(from, Duration.ofNanos(elapsedNs));
+                }
+            } else {
+                // ICMPv4 type 0 = echo reply; type 11 = time exceeded
+                if (icmpType == 0) {
+                    // Echo reply – check identifier and sequence
+                    int replyId  = ((raw[icmpOffset + 4] & 0xFF) << 8) | (raw[icmpOffset + 5] & 0xFF);
+                    int replySeq = ((raw[icmpOffset + 6] & 0xFF) << 8) | (raw[icmpOffset + 7] & 0xFF);
+                    if (replyId != expectedId || replySeq != expectedSeq) return null;
+                    return new ProbeResult(from, Duration.ofNanos(elapsedNs));
+                } else if (icmpType == 11) {
+                    // Time exceeded – intermediate hop; valid for MTR
+                    return new ProbeResult(from, Duration.ofNanos(elapsedNs));
+                } else if (icmpType == 3) {
+                    // Destination unreachable – still a valid hop response
+                    return new ProbeResult(from, Duration.ofNanos(elapsedNs));
+                }
+            }
+
+            return null; // unexpected ICMP type
+        } catch (UnknownHostException e) {
+            throw new MtrException("Failed to parse reply address", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // sockaddr builders
+    // -------------------------------------------------------------------------
+
+    private static MemorySegment buildSockAddrIn4(Arena arena, byte[] ipv4) {
+        MemorySegment seg = arena.allocate(LibcSocket.SOCKADDR_IN_SIZE);
+        // sin_family = AF_INET (2), little-endian short
+        seg.set(ValueLayout.JAVA_SHORT, LibcSocket.SA_OFFSET_FAMILY, (short) LibcSocket.AF_INET);
+        seg.set(ValueLayout.JAVA_SHORT, LibcSocket.SA_OFFSET_PORT, (short) 0);
+        MemorySegment.copy(ipv4, 0, seg, ValueLayout.JAVA_BYTE, LibcSocket.SA_OFFSET_ADDR, 4);
+        return seg;
+    }
+
+    private MemorySegment buildSockAddrIn6(Arena arena, byte[] ipv6) {
+        MemorySegment seg = arena.allocate(LibcSocket.SOCKADDR_IN6_SIZE);
+        seg.set(ValueLayout.JAVA_SHORT, LibcSocket.SA6_OFFSET_FAMILY, (short) getAf6());
+        seg.set(ValueLayout.JAVA_SHORT, LibcSocket.SA6_OFFSET_PORT, (short) 0);
+        seg.set(ValueLayout.JAVA_INT,   LibcSocket.SA6_OFFSET_FLOWINFO, 0);
+        MemorySegment.copy(ipv6, 0, seg, ValueLayout.JAVA_BYTE, LibcSocket.SA6_OFFSET_ADDR, 16);
+        seg.set(ValueLayout.JAVA_INT, LibcSocket.SA6_OFFSET_SCOPE_ID, 0);
+        return seg;
+    }
+
+    // -------------------------------------------------------------------------
+    // Address extraction from received sockaddr
+    // -------------------------------------------------------------------------
+
+    private static InetAddress extractAddrV4(MemorySegment sockAddr)
+            throws UnknownHostException {
+        byte[] addr = new byte[4];
+        MemorySegment.copy(sockAddr, ValueLayout.JAVA_BYTE,
+                           LibcSocket.SA_OFFSET_ADDR, addr, 0, 4);
+        return InetAddress.getByAddress(addr);
+    }
+
+    private static InetAddress extractAddrV6(MemorySegment sockAddr)
+            throws UnknownHostException {
+        byte[] addr = new byte[16];
+        MemorySegment.copy(sockAddr, ValueLayout.JAVA_BYTE,
+                           LibcSocket.SA6_OFFSET_ADDR, addr, 0, 16);
+        return InetAddress.getByAddress(addr);
+    }
+
+    // -------------------------------------------------------------------------
+    // Socket availability probe (used at construction)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Tries to open a test socket (immediately closed) to determine which mode
+     * is available.
+     *
+     * @param isV6 {@code true} to test IPv6
+     * @return result containing mode or error reason
+     */
+    private SocketProbeResult probeSocketAvailability(boolean isV6) {
+        int af       = isV6 ? getAf6() : LibcSocket.AF_INET;
+        int protocol = isV6 ? LibcSocket.IPPROTO_ICMPV6 : LibcSocket.IPPROTO_ICMP;
+
+        // On macOS + IPv6, skip DGRAM attempt (unreliable without root)
+        if (!isMacOs || !isV6) {
+            int fd = LibcSocket.socket(af, LibcSocket.SOCK_DGRAM, protocol);
+            if (fd >= 0) {
+                LibcSocket.close(fd);
+                return SocketProbeResult.ok(PosixSocketMode.DGRAM_UNPRIVILEGED);
+            }
+            int err = LibcSocket.errno();
+            log.debug("SOCK_DGRAM ICMP{} not available, errno={}", isV6 ? "V6" : "", err);
+            if (err != LibcSocket.EPERM && err != LibcSocket.EACCES) {
+                return SocketProbeResult.fail("SOCK_DGRAM failed with errno=" + err);
+            }
+        }
+
+        // Try RAW
+        int fd = LibcSocket.socket(af, LibcSocket.SOCK_RAW, protocol);
+        if (fd >= 0) {
+            LibcSocket.close(fd);
+            return SocketProbeResult.ok(PosixSocketMode.RAW_PRIVILEGED);
+        }
+        int err = LibcSocket.errno();
+        return SocketProbeResult.fail("SOCK_RAW also failed with errno=" + err);
+    }
+
+    // -------------------------------------------------------------------------
+    // Hostname resolution
+    // -------------------------------------------------------------------------
+
+    private List<MtrHop> resolveHostnames(List<MtrHop> hops) {
+        try (ExecutorService ex = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<String>> futs = new ArrayList<>(hops.size());
+            for (MtrHop hop : hops) {
+                if (hop.getAddress() != null) {
+                    final InetAddress addr = hop.getAddress();
+                    futs.add(ex.submit(() -> {
+                        try {
+                            return InetAddress.getByAddress(addr.getAddress()).getHostName();
+                        } catch (Exception ignored) { return null; }
+                    }));
+                } else {
+                    futs.add(CompletableFuture.completedFuture(null));
+                }
+            }
+            List<MtrHop> resolved = new ArrayList<>(hops.size());
+            for (int i = 0; i < hops.size(); i++) {
+                MtrHop hop = hops.get(i);
+                String hostname = null;
+                try { hostname = futs.get(i).get(2, TimeUnit.SECONDS); }
+                catch (Exception ignored) {}
+                if (hostname != null && hop.getAddress() != null
+                        && hostname.equals(hop.getAddress().getHostAddress())) {
+                    hostname = null;
+                }
+                resolved.add(new MtrHop(
+                        hop.getTtl(), hop.getAddress(), hostname,
+                        hop.getRtts(), hop.getSent(), hop.getReceived()));
+            }
+            return resolved;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Utilities
+    // -------------------------------------------------------------------------
+
+    /** AF_INET6 value: 10 on Linux, 30 on macOS. */
+    private int getAf6() {
+        return isMacOs ? 30 : 10;
+    }
+
+    private static byte[] buildPayload(int size) {
+        byte[] buf = new byte[size];
+        for (int i = 0; i < size; i++) buf[i] = (byte) (i & 0xFF);
+        return buf;
+    }
+
+    private static MtrHop unresponsiveHop(int ttl, int probeCount) {
+        return new MtrHop(ttl, null, null, Collections.emptyList(), probeCount, 0);
+    }
+
+    private static byte[] segmentToBytes(MemorySegment seg, long len) {
+        int n = (int) Math.min(len, seg.byteSize());
+        byte[] buf = new byte[n];
+        MemorySegment.copy(seg, ValueLayout.JAVA_BYTE, 0, buf, 0, n);
+        return buf;
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner types
+    // -------------------------------------------------------------------------
+
+    private record ProbeResult(InetAddress from, Duration rtt) {}
+
+    private record SocketProbeResult(@Nullable PosixSocketMode mode,
+                                     @Nullable String errorReason) {
+        static SocketProbeResult ok(PosixSocketMode m)     { return new SocketProbeResult(m, null);     }
+        static SocketProbeResult fail(String reason)       { return new SocketProbeResult(null, reason); }
+    }
+}
+
+
+
+
+
+
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/PosixSocketMode.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/posix/mtr/PosixSocketMode.java
@@ -1,0 +1,19 @@
+package com.ghostchu.peerbanhelper.platform.impl.posix.mtr;
+
+/**
+ * Describes which mode was successfully used to open an ICMP socket.
+ */
+public enum PosixSocketMode {
+    /**
+     * {@code SOCK_DGRAM + IPPROTO_ICMP} – unprivileged mode.
+     * Works on Linux when {@code net.ipv4.ping_group_range} allows the current
+     * user, and on macOS without any special configuration.
+     */
+    DGRAM_UNPRIVILEGED,
+
+    /**
+     * {@code SOCK_RAW + IPPROTO_ICMP} – requires root or {@code CAP_NET_RAW}.
+     */
+    RAW_PRIVILEGED
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/WindowsPlatform.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/WindowsPlatform.java
@@ -4,14 +4,29 @@ import com.ghostchu.peerbanhelper.ExternalSwitch;
 import com.ghostchu.peerbanhelper.platform.Platform;
 import com.ghostchu.peerbanhelper.platform.WindowsEcoQosAPI;
 import com.ghostchu.peerbanhelper.platform.impl.win32.amsi.AmsiScanner;
+import com.ghostchu.peerbanhelper.platform.impl.win32.mtr.WindowsMtrTool;
 import com.ghostchu.peerbanhelper.platform.types.EcoQosAPI;
 import com.ghostchu.peerbanhelper.platform.types.MalwareScanner;
+import com.ghostchu.peerbanhelper.platform.types.MtrTool;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
 @Slf4j
 public class WindowsPlatform implements Platform {
     private final EcoQosAPI ecoQosAPI = new WindowsEcoQosAPI();
+
+    @Nullable
+    private final MtrTool mtrTool;
+
+    public WindowsPlatform() {
+        MtrTool tool = null;
+        try {
+            tool = new WindowsMtrTool();
+        } catch (Exception e) {
+            log.debug("WindowsMtrTool initialisation failed – MTR not available: {}", e.getMessage());
+        }
+        this.mtrTool = tool;
+    }
 
     @Override
     public @Nullable EcoQosAPI getEcoQosAPI() {
@@ -32,5 +47,13 @@ public class WindowsPlatform implements Platform {
             log.debug("AMSI Scanner is not available: {}", e.getMessage());
             return null;
         }
+    }
+
+    @Override
+    public @Nullable MtrTool getMtrTool() {
+        if (!ExternalSwitch.parseBoolean("pbh.platform.mtr", true)) {
+            return null;
+        }
+        return mtrTool;
     }
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/IcmpEchoReplyLayout.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/IcmpEchoReplyLayout.java
@@ -1,0 +1,173 @@
+package com.ghostchu.peerbanhelper.platform.impl.win32.mtr;
+
+import java.lang.foreign.*;
+
+/**
+ * Memory layout helpers for Windows ICMP reply structures.
+ *
+ * <h2>IP_OPTION_INFORMATION (used as RequestOptions)</h2>
+ * <pre>
+ * typedef struct ip_option_information {
+ *   UCHAR  Ttl;          // 1 byte  offset 0
+ *   UCHAR  Tos;          // 1 byte  offset 1
+ *   UCHAR  Flags;        // 1 byte  offset 2
+ *   UCHAR  OptionsSize;  // 1 byte  offset 3
+ *   PUCHAR OptionsData;  // pointer offset 4  (8 bytes on 64-bit)
+ * } IP_OPTION_INFORMATION;
+ * </pre>
+ * Total size: 12 bytes on 64-bit Windows (4 bytes + 4-byte padding + 8-byte ptr).
+ *
+ * <h2>ICMP_ECHO_REPLY (IPv4)</h2>
+ * <pre>
+ * typedef struct icmp_echo_reply {
+ *   IPAddr  Address;      // DWORD  offset 0
+ *   ULONG   Status;       // DWORD  offset 4
+ *   ULONG   RoundTripTime;// DWORD  offset 8
+ *   USHORT  DataSize;     // WORD   offset 12
+ *   USHORT  Reserved;     // WORD   offset 14
+ *   PVOID   Data;         // PTR    offset 16 (8 bytes on 64-bit)
+ *   IP_OPTION_INFORMATION Options; // offset 24
+ * } ICMP_ECHO_REPLY;
+ * </pre>
+ *
+ * <h2>ICMPV6_ECHO_REPLY (IPv6)</h2>
+ * <pre>
+ * typedef struct icmpv6_echo_reply_lh {
+ *   IPV6_ADDRESS_EX Address;   // 28 bytes  offset 0
+ *   ULONG           Status;    // DWORD     offset 28
+ *   unsigned int    RoundTripTime; // DWORD offset 32
+ * } ICMPV6_ECHO_REPLY;
+ * </pre>
+ * IPV6_ADDRESS_EX:
+ *   USHORT sin6_port   (2)
+ *   ULONG  sin6_flowinfo (4)
+ *   USHORT sin6_addr[8] (16)
+ *   ULONG  sin6_scope_id (4)
+ *   = 26 bytes, padded to 28 with 2 bytes
+ */
+public final class IcmpEchoReplyLayout {
+
+    // =========================================================================
+    // IP_OPTION_INFORMATION
+    // =========================================================================
+
+    /**
+     * Layout of {@code IP_OPTION_INFORMATION} on 64-bit Windows.
+     *
+     * <pre>
+     * UCHAR  Ttl;         offset 0
+     * UCHAR  Tos;         offset 1
+     * UCHAR  Flags;       offset 2
+     * UCHAR  OptionsSize; offset 3
+     * PUCHAR OptionsData; offset 8  (4-byte alignment padding at offset 4–7)
+     * </pre>
+     */
+    public static final StructLayout IP_OPTION_INFORMATION = MemoryLayout.structLayout(
+            ValueLayout.JAVA_BYTE.withName("Ttl"),           // offset 0
+            ValueLayout.JAVA_BYTE.withName("Tos"),           // offset 1
+            ValueLayout.JAVA_BYTE.withName("Flags"),         // offset 2
+            ValueLayout.JAVA_BYTE.withName("OptionsSize"),   // offset 3
+            MemoryLayout.paddingLayout(4),                   // padding to align pointer
+            ValueLayout.ADDRESS.withName("OptionsData")      // offset 8
+    );
+
+    public static final long IP_OPT_OFFSET_TTL = IP_OPTION_INFORMATION
+            .byteOffset(MemoryLayout.PathElement.groupElement("Ttl"));
+    public static final long IP_OPT_OFFSET_TOS = IP_OPTION_INFORMATION
+            .byteOffset(MemoryLayout.PathElement.groupElement("Tos"));
+    public static final long IP_OPT_OFFSET_FLAGS = IP_OPTION_INFORMATION
+            .byteOffset(MemoryLayout.PathElement.groupElement("Flags"));
+
+    // =========================================================================
+    // ICMP_ECHO_REPLY (IPv4)
+    // =========================================================================
+
+    /**
+     * Layout of {@code ICMP_ECHO_REPLY} on 64-bit Windows.
+     * We only need the first three DWORD fields for MTR; the rest is ignored.
+     */
+    public static final StructLayout ICMP_ECHO_REPLY = MemoryLayout.structLayout(
+            ValueLayout.JAVA_INT.withName("Address"),        // offset 0  – reply source IPv4 (big-endian)
+            ValueLayout.JAVA_INT.withName("Status"),         // offset 4  – IcmpLib.IP_* constants
+            ValueLayout.JAVA_INT.withName("RoundTripTime"),  // offset 8  – RTT in milliseconds
+            ValueLayout.JAVA_SHORT.withName("DataSize"),     // offset 12
+            ValueLayout.JAVA_SHORT.withName("Reserved"),     // offset 14
+            ValueLayout.ADDRESS.withName("Data"),            // offset 16 – pointer
+            // Embed IP_OPTION_INFORMATION (16 bytes)
+            ValueLayout.JAVA_BYTE.withName("opt_Ttl"),
+            ValueLayout.JAVA_BYTE.withName("opt_Tos"),
+            ValueLayout.JAVA_BYTE.withName("opt_Flags"),
+            ValueLayout.JAVA_BYTE.withName("opt_OptionsSize"),
+            MemoryLayout.paddingLayout(4),
+            ValueLayout.ADDRESS.withName("opt_OptionsData")
+    );
+
+    public static final long ECHO_REPLY_OFFSET_ADDRESS =
+            ICMP_ECHO_REPLY.byteOffset(MemoryLayout.PathElement.groupElement("Address"));
+    public static final long ECHO_REPLY_OFFSET_STATUS =
+            ICMP_ECHO_REPLY.byteOffset(MemoryLayout.PathElement.groupElement("Status"));
+    public static final long ECHO_REPLY_OFFSET_RTT =
+            ICMP_ECHO_REPLY.byteOffset(MemoryLayout.PathElement.groupElement("RoundTripTime"));
+
+    // =========================================================================
+    // ICMPV6_ECHO_REPLY (IPv6)
+    // =========================================================================
+
+    /**
+     * Layout for {@code ICMPV6_ECHO_REPLY} on 64-bit Windows.
+     *
+     * <pre>
+     * USHORT  sin6_port       offset 0   (2 bytes)
+     * ULONG   sin6_flowinfo   offset 2   (4 bytes – unaligned in C struct)
+     * USHORT  sin6_addr[8]    offset 6   (16 bytes)
+     * ULONG   sin6_scope_id   offset 22  (4 bytes)
+     *                         2 bytes padding → total Address = 28 bytes
+     * ULONG   Status          offset 28
+     * UINT    RoundTripTime   offset 32
+     * </pre>
+     */
+    // We model this as a flat byte array for the address part plus two ints.
+    // The address bytes [6..21] are the 16-byte IPv6 address.
+    public static final long ECHO6_REPLY_SIZE = 36L; // 28 + 4 + 4
+
+    /** Byte offset of the 16-byte IPv6 address inside ICMPV6_ECHO_REPLY. */
+    public static final int  ECHO6_ADDR_OFFSET    = 6;
+    /** Byte offset of Status (ULONG) inside ICMPV6_ECHO_REPLY. */
+    public static final int  ECHO6_STATUS_OFFSET  = 28;
+    /** Byte offset of RoundTripTime (UINT) inside ICMPV6_ECHO_REPLY. */
+    public static final int  ECHO6_RTT_OFFSET     = 32;
+
+    // =========================================================================
+    // sockaddr_in6 layout (for Icmp6SendEcho2 src/dst parameters)
+    // =========================================================================
+
+    /**
+     * Minimal {@code sockaddr_in6} layout (28 bytes on Windows):
+     * <pre>
+     * USHORT  sin6_family    offset 0
+     * USHORT  sin6_port      offset 2
+     * ULONG   sin6_flowinfo  offset 4
+     * UCHAR   sin6_addr[16]  offset 8
+     * ULONG   sin6_scope_id  offset 24
+     * </pre>
+     */
+    public static final long SOCKADDR_IN6_SIZE = 28L;
+
+    public static final int SA6_OFFSET_FAMILY    = 0;
+    public static final int SA6_OFFSET_PORT      = 2;
+    public static final int SA6_OFFSET_FLOWINFO  = 4;
+    public static final int SA6_OFFSET_ADDR      = 8;
+    public static final int SA6_OFFSET_SCOPE_ID  = 24;
+
+    /** AF_INET6 on Windows. */
+    public static final short AF_INET6 = 23;
+
+    // Minimum reply buffer sizes
+    /** Minimum reply buffer for one IPv4 echo reply. */
+    public static final int  IPV4_REPLY_BUFFER_SIZE = 1024;
+    /** Minimum reply buffer for one IPv6 echo reply. */
+    public static final int  IPV6_REPLY_BUFFER_SIZE = 1024;
+
+    private IcmpEchoReplyLayout() {}
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/IcmpLib.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/IcmpLib.java
@@ -1,0 +1,294 @@
+package com.ghostchu.peerbanhelper.platform.impl.win32.mtr;
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+
+/**
+ * FFM bindings for the Windows ICMP helper API provided by {@code iphlpapi.dll}.
+ *
+ * <p>Windows exposes a high-level ICMP API that does NOT require administrator
+ * privileges, which makes it ideal for MTR:
+ * <ul>
+ *   <li>{@code IcmpCreateFile} / {@code Icmp6CreateFile} – open an ICMP handle</li>
+ *   <li>{@code IcmpSendEcho2Ex} / {@code Icmp6SendEcho2} – send one echo request
+ *       with a specific TTL and wait for the reply (supports timeout)</li>
+ *   <li>{@code IcmpCloseHandle} – release the handle</li>
+ * </ul>
+ *
+ * <p>All method handles are initialised once at class-load time using
+ * {@link Arena#global()} so they survive for the lifetime of the JVM.
+ */
+public final class IcmpLib {
+
+    // -------------------------------------------------------------------------
+    // Library / Linker setup
+    // -------------------------------------------------------------------------
+
+    private static final Linker          LINKER    = Linker.nativeLinker();
+    private static final SymbolLookup    IPHLPAPI  = SymbolLookup.libraryLookup("iphlpapi", Arena.global());
+
+    // -------------------------------------------------------------------------
+    // Constant: invalid handle value returned on failure
+    // -------------------------------------------------------------------------
+
+    /** Equivalent to {@code INVALID_HANDLE_VALUE} (cast to pointer) on 64-bit Windows. */
+    public static final long INVALID_HANDLE_VALUE = -1L;  // 0xFFFFFFFF_FFFFFFFF
+
+    // -------------------------------------------------------------------------
+    // Return codes embedded in ICMP_ECHO_REPLY.Status
+    // -------------------------------------------------------------------------
+
+    /** IP_SUCCESS – the destination echoed our packet. */
+    public static final int IP_SUCCESS               = 0;
+    /** IP_TTL_EXPIRED_TRANSIT – intermediate router replied "TTL expired". */
+    public static final int IP_TTL_EXPIRED_TRANSIT   = 11013;
+    /** IP_TTL_EXPIRED_REASSEM – TTL expired during reassembly (rare). */
+    public static final int IP_TTL_EXPIRED_REASSEM   = 11014;
+    /** IP_REQ_TIMED_OUT – probe timed out. */
+    public static final int IP_REQ_TIMED_OUT         = 11010;
+    /** IP_DEST_NET_UNREACHABLE */
+    public static final int IP_DEST_NET_UNREACHABLE  = 11002;
+    /** IP_DEST_HOST_UNREACHABLE */
+    public static final int IP_DEST_HOST_UNREACHABLE = 11003;
+    /** IP_DEST_PORT_UNREACHABLE */
+    public static final int IP_DEST_PORT_UNREACHABLE = 11005;
+
+    // -------------------------------------------------------------------------
+    // HANDLE IcmpCreateFile()
+    // -------------------------------------------------------------------------
+
+    private static final MethodHandle MH_ICMP_CREATE_FILE = LINKER.downcallHandle(
+            IPHLPAPI.find("IcmpCreateFile").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS)
+    );
+
+    // -------------------------------------------------------------------------
+    // HANDLE Icmp6CreateFile()
+    // -------------------------------------------------------------------------
+
+    private static final MethodHandle MH_ICMP6_CREATE_FILE = LINKER.downcallHandle(
+            IPHLPAPI.find("Icmp6CreateFile").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.ADDRESS)
+    );
+
+    // -------------------------------------------------------------------------
+    // BOOL IcmpCloseHandle(HANDLE IcmpHandle)
+    // -------------------------------------------------------------------------
+
+    private static final MethodHandle MH_ICMP_CLOSE_HANDLE = LINKER.downcallHandle(
+            IPHLPAPI.find("IcmpCloseHandle").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,
+                    ValueLayout.ADDRESS)   // IcmpHandle
+    );
+
+    // -------------------------------------------------------------------------
+    // DWORD IcmpSendEcho2Ex(
+    //   HANDLE          IcmpHandle,
+    //   HANDLE          Event,              // NULL
+    //   FARPROC         ApcRoutine,         // NULL
+    //   PVOID           ApcContext,         // NULL
+    //   IPAddr          SourceAddress,      // DWORD (IPv4 src, may be 0)
+    //   IPAddr          DestinationAddress, // DWORD (IPv4 dst, big-endian)
+    //   LPVOID          RequestData,
+    //   WORD            RequestSize,
+    //   PIP_OPTION_INFORMATION RequestOptions, // pointer to struct (TTL, TOS …)
+    //   LPVOID          ReplyBuffer,
+    //   DWORD           ReplySize,
+    //   DWORD           Timeout             // ms
+    // )
+    // -------------------------------------------------------------------------
+
+    private static final MethodHandle MH_ICMP_SEND_ECHO2EX = LINKER.downcallHandle(
+            IPHLPAPI.find("IcmpSendEcho2Ex").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,  // DWORD return (reply count)
+                    ValueLayout.ADDRESS,   // IcmpHandle
+                    ValueLayout.ADDRESS,   // Event (NULL)
+                    ValueLayout.ADDRESS,   // ApcRoutine (NULL)
+                    ValueLayout.ADDRESS,   // ApcContext (NULL)
+                    ValueLayout.JAVA_INT,  // SourceAddress (IPAddr = DWORD)
+                    ValueLayout.JAVA_INT,  // DestinationAddress (IPAddr = DWORD)
+                    ValueLayout.ADDRESS,   // RequestData
+                    ValueLayout.JAVA_SHORT,// RequestSize (WORD)
+                    ValueLayout.ADDRESS,   // RequestOptions (IP_OPTION_INFORMATION*)
+                    ValueLayout.ADDRESS,   // ReplyBuffer
+                    ValueLayout.JAVA_INT,  // ReplySize
+                    ValueLayout.JAVA_INT)  // Timeout (ms)
+    );
+
+    // -------------------------------------------------------------------------
+    // DWORD Icmp6SendEcho2(
+    //   HANDLE          IcmpHandle,
+    //   HANDLE          Event,
+    //   FARPROC         ApcRoutine,
+    //   PVOID           ApcContext,
+    //   sockaddr_in6*   SourceAddress,
+    //   sockaddr_in6*   DestinationAddress,
+    //   LPVOID          RequestData,
+    //   WORD            RequestSize,
+    //   PIP_OPTION_INFORMATION RequestOptions,
+    //   LPVOID          ReplyBuffer,
+    //   DWORD           ReplySize,
+    //   DWORD           Timeout
+    // )
+    // -------------------------------------------------------------------------
+
+    private static final MethodHandle MH_ICMP6_SEND_ECHO2 = LINKER.downcallHandle(
+            IPHLPAPI.find("Icmp6SendEcho2").orElseThrow(),
+            FunctionDescriptor.of(ValueLayout.JAVA_INT,  // DWORD return
+                    ValueLayout.ADDRESS,   // IcmpHandle
+                    ValueLayout.ADDRESS,   // Event (NULL)
+                    ValueLayout.ADDRESS,   // ApcRoutine (NULL)
+                    ValueLayout.ADDRESS,   // ApcContext (NULL)
+                    ValueLayout.ADDRESS,   // SourceAddress (sockaddr_in6*)
+                    ValueLayout.ADDRESS,   // DestinationAddress (sockaddr_in6*)
+                    ValueLayout.ADDRESS,   // RequestData
+                    ValueLayout.JAVA_SHORT,// RequestSize
+                    ValueLayout.ADDRESS,   // RequestOptions
+                    ValueLayout.ADDRESS,   // ReplyBuffer
+                    ValueLayout.JAVA_INT,  // ReplySize
+                    ValueLayout.JAVA_INT)  // Timeout
+    );
+
+    // -------------------------------------------------------------------------
+    // Private constructor – utility class
+    // -------------------------------------------------------------------------
+
+    private IcmpLib() {}
+
+    // -------------------------------------------------------------------------
+    // Public wrappers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Opens an IPv4 ICMP handle.
+     *
+     * @return handle segment; check {@link #isInvalidHandle} before use.
+     */
+    public static MemorySegment icmpCreateFile() {
+        try {
+            return (MemorySegment) MH_ICMP_CREATE_FILE.invokeExact();
+        } catch (Throwable t) {
+            throw new RuntimeException("IcmpCreateFile failed", t);
+        }
+    }
+
+    /**
+     * Opens an IPv6 ICMP handle.
+     *
+     * @return handle segment; check {@link #isInvalidHandle} before use.
+     */
+    public static MemorySegment icmp6CreateFile() {
+        try {
+            return (MemorySegment) MH_ICMP6_CREATE_FILE.invokeExact();
+        } catch (Throwable t) {
+            throw new RuntimeException("Icmp6CreateFile failed", t);
+        }
+    }
+
+    /**
+     * Closes an ICMP handle previously opened via {@link #icmpCreateFile()} or
+     * {@link #icmp6CreateFile()}.
+     *
+     * @return non-zero on success
+     */
+    public static int icmpCloseHandle(MemorySegment icmpHandle) {
+        try {
+            return (int) MH_ICMP_CLOSE_HANDLE.invokeExact(icmpHandle);
+        } catch (Throwable t) {
+            throw new RuntimeException("IcmpCloseHandle failed", t);
+        }
+    }
+
+    /**
+     * Sends one IPv4 ICMP echo request and waits for a reply.
+     *
+     * @param icmpHandle     handle from {@link #icmpCreateFile()}
+     * @param srcAddr        source IPv4 address as big-endian int (0 = any)
+     * @param dstAddr        destination IPv4 address as big-endian int
+     * @param requestData    payload segment
+     * @param requestSize    payload length (WORD)
+     * @param requestOptions IP_OPTION_INFORMATION segment (TTL, TOS, …)
+     * @param replyBuffer    output buffer (must be pre-allocated)
+     * @param replySize      size of reply buffer in bytes
+     * @param timeoutMs      send timeout in milliseconds
+     * @return number of replies received (0 = timeout / error)
+     */
+    public static int icmpSendEcho2Ex(MemorySegment icmpHandle,
+                                      int srcAddr, int dstAddr,
+                                      MemorySegment requestData, short requestSize,
+                                      MemorySegment requestOptions,
+                                      MemorySegment replyBuffer, int replySize,
+                                      int timeoutMs) {
+        try {
+            return (int) MH_ICMP_SEND_ECHO2EX.invokeExact(
+                    icmpHandle,
+                    MemorySegment.NULL,  // Event
+                    MemorySegment.NULL,  // ApcRoutine
+                    MemorySegment.NULL,  // ApcContext
+                    srcAddr,
+                    dstAddr,
+                    requestData,
+                    requestSize,
+                    requestOptions,
+                    replyBuffer,
+                    replySize,
+                    timeoutMs);
+        } catch (Throwable t) {
+            throw new RuntimeException("IcmpSendEcho2Ex failed", t);
+        }
+    }
+
+    /**
+     * Sends one IPv6 ICMP echo request and waits for a reply.
+     *
+     * @param icmpHandle     handle from {@link #icmp6CreateFile()}
+     * @param srcAddr        sockaddr_in6 segment for source (port=0 is fine)
+     * @param dstAddr        sockaddr_in6 segment for destination
+     * @param requestData    payload segment
+     * @param requestSize    payload length (WORD)
+     * @param requestOptions IP_OPTION_INFORMATION segment (Ttl field matters)
+     * @param replyBuffer    output buffer
+     * @param replySize      size of reply buffer in bytes
+     * @param timeoutMs      send timeout in milliseconds
+     * @return number of replies received
+     */
+    public static int icmp6SendEcho2(MemorySegment icmpHandle,
+                                     MemorySegment srcAddr, MemorySegment dstAddr,
+                                     MemorySegment requestData, short requestSize,
+                                     MemorySegment requestOptions,
+                                     MemorySegment replyBuffer, int replySize,
+                                     int timeoutMs) {
+        try {
+            return (int) MH_ICMP6_SEND_ECHO2.invokeExact(
+                    icmpHandle,
+                    MemorySegment.NULL,
+                    MemorySegment.NULL,
+                    MemorySegment.NULL,
+                    srcAddr,
+                    dstAddr,
+                    requestData,
+                    requestSize,
+                    requestOptions,
+                    replyBuffer,
+                    replySize,
+                    timeoutMs);
+        } catch (Throwable t) {
+            throw new RuntimeException("Icmp6SendEcho2 failed", t);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns {@code true} when the handle value equals
+     * {@code INVALID_HANDLE_VALUE} (i.e., creation failed).
+     */
+    public static boolean isInvalidHandle(MemorySegment handle) {
+        // On 64-bit Windows INVALID_HANDLE_VALUE is 0xFFFFFFFFFFFFFFFF.
+        // MemorySegment.address() returns a raw long pointer value.
+        return handle.address() == INVALID_HANDLE_VALUE || handle.equals(MemorySegment.NULL);
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/WindowsMtrTool.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/impl/win32/mtr/WindowsMtrTool.java
@@ -1,0 +1,516 @@
+package com.ghostchu.peerbanhelper.platform.impl.win32.mtr;
+
+import com.ghostchu.peerbanhelper.platform.mtr.MtrHop;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrOptions;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrResult;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrException;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrTimeoutException;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrUnsupportedException;
+import com.ghostchu.peerbanhelper.platform.types.MtrTool;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.ValueLayout;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.*;
+import java.util.concurrent.*;
+
+/**
+ * Windows implementation of {@link MtrTool} using the high-level
+ * {@code iphlpapi.dll} ICMP API.
+ *
+ * <p>Key properties:
+ * <ul>
+ *   <li>Works without administrator / elevated privileges.</li>
+ *   <li>All TTL levels are probed <em>in parallel</em> using virtual threads for
+ *       maximum performance.</li>
+ *   <li>Each probe is retried up to {@link MtrOptions#getRetryCount()} times on
+ *       timeout before being counted as a loss.</li>
+ *   <li>Supports both IPv4 ({@code IcmpSendEcho2Ex}) and IPv6
+ *       ({@code Icmp6SendEcho2}).</li>
+ * </ul>
+ */
+@Slf4j
+public final class WindowsMtrTool implements MtrTool {
+
+    /** Shared IPv4 ICMP handle (opened once, kept for the life of the object). */
+    private final MemorySegment icmpHandle4;
+
+    /** Shared IPv6 ICMP handle – may be {@code null} if Icmp6CreateFile failed. */
+    @Nullable
+    private final MemorySegment icmpHandle6;
+
+    /** Whether the IPv6 handle was successfully opened. */
+    private final boolean ipv6Available;
+
+    // -------------------------------------------------------------------------
+    // Construction / teardown
+    // -------------------------------------------------------------------------
+
+    public WindowsMtrTool() {
+        // IPv4 handle – must succeed
+        MemorySegment h4 = IcmpLib.icmpCreateFile();
+        if (IcmpLib.isInvalidHandle(h4)) {
+            throw new RuntimeException("IcmpCreateFile returned INVALID_HANDLE_VALUE");
+        }
+        this.icmpHandle4 = h4;
+
+        // IPv6 handle – best-effort
+        MemorySegment h6 = null;
+        boolean v6ok = false;
+        try {
+            h6 = IcmpLib.icmp6CreateFile();
+            v6ok = !IcmpLib.isInvalidHandle(h6);
+            if (!v6ok) {
+                log.debug("Icmp6CreateFile returned INVALID_HANDLE_VALUE; IPv6 MTR not available");
+                h6 = null;
+            }
+        } catch (Exception e) {
+            log.debug("Icmp6CreateFile threw exception; IPv6 MTR not available: {}", e.getMessage());
+        }
+        this.icmpHandle6 = h6;
+        this.ipv6Available = v6ok;
+    }
+
+    public void close() {
+        try { IcmpLib.icmpCloseHandle(icmpHandle4); } catch (Exception ignored) {}
+        if (icmpHandle6 != null) {
+            try { IcmpLib.icmpCloseHandle(icmpHandle6); } catch (Exception ignored) {}
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // MtrTool interface
+    // -------------------------------------------------------------------------
+
+    @Override
+    public boolean isSupported(@NotNull InetAddress target) {
+        if (target instanceof Inet4Address) return true;
+        if (target instanceof Inet6Address) return ipv6Available;
+        return false;
+    }
+
+    @Override
+    public @NotNull MtrResult trace(@NotNull InetAddress target, @NotNull MtrOptions options)
+            throws MtrException {
+        if (!isSupported(target)) {
+            throw new MtrUnsupportedException(
+                    "IPv6 ICMP tracing is not available on this system (Icmp6CreateFile failed)");
+        }
+
+        Instant start = Instant.now();
+
+        // Build a random payload once; reuse across probes for efficiency
+        byte[] payload = buildPayload(options.getPayloadSize());
+
+        // Launch all TTL probes in parallel using virtual threads
+        List<Future<MtrHop>> futures = new ArrayList<>(options.getMaxHops());
+        long totalDeadlineMs = options.getTotalTimeout().toMillis();
+        List<MtrHop> hops = new ArrayList<>(options.getMaxHops());
+
+        try (ExecutorService exec = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int ttl = 1; ttl <= options.getMaxHops(); ttl++) {
+                final int currentTtl = ttl;
+                futures.add(exec.submit(() -> probeHop(target, currentTtl, payload, options)));
+            }
+            exec.shutdown();
+            try {
+                if (!exec.awaitTermination(totalDeadlineMs, TimeUnit.MILLISECONDS)) {
+                    exec.shutdownNow();
+                    throw new MtrTimeoutException(
+                            "Total trace timeout exceeded (" + options.getTotalTimeout() + ")");
+                }
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MtrException("Trace interrupted", e);
+            }
+        }
+
+        // Collect results in TTL order
+        for (int ttl = 1; ttl <= options.getMaxHops(); ttl++) {
+            Future<MtrHop> f = futures.get(ttl - 1);
+            MtrHop hop;
+            try {
+                hop = f.get();
+            } catch (ExecutionException e) {
+                log.debug("TTL={} probe threw: {}", ttl, e.getCause().getMessage());
+                hop = unresponsiveHop(ttl, options.getProbeCount());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new MtrException("Trace interrupted while collecting hop " + ttl, e);
+            } catch (CancellationException e) {
+                hop = unresponsiveHop(ttl, options.getProbeCount());
+            }
+            hops.add(hop);
+
+            if (hop.getAddress() != null && hop.getAddress().equals(target)) {
+                break; // reached destination – stop collecting
+            }
+        }
+
+        // Optionally resolve PTR for each hop (batch, after probing)
+        if (options.isResolveHostnames()) {
+            hops = resolveHostnames(hops);
+        }
+
+        Duration elapsed = Duration.between(start, Instant.now());
+        return new MtrResult(target, hops, start, elapsed);
+    }
+
+    // -------------------------------------------------------------------------
+    // Per-hop probing
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sends {@code probeCount} probes at the given TTL.  Each probe is retried
+     * up to {@code retryCount} times on timeout.
+     */
+    private MtrHop probeHop(InetAddress target, int ttl, byte[] payload, MtrOptions options)
+            throws MtrException {
+        List<Duration> rtts = new ArrayList<>(options.getProbeCount());
+        int sent     = 0;
+        int received = 0;
+        InetAddress replyAddr = null;
+
+        for (int probe = 0; probe < options.getProbeCount(); probe++) {
+            sent++;
+            Duration rtt = null;
+
+            for (int attempt = 0; attempt <= options.getRetryCount(); attempt++) {
+                long timeoutMs = computeAttemptTimeoutMs(options);
+                ProbeResult result = sendSingleProbe(target, ttl, payload, (int) timeoutMs, options);
+
+                if (result != null) {
+                    // Got a reply (TTL-expired or echo-reply)
+                    rtt = result.rtt;
+                    if (replyAddr == null) replyAddr = result.from;
+                    break; // no more retries needed
+                }
+                // else: timed out – retry if attempts remain
+            }
+
+            if (rtt != null) {
+                rtts.add(rtt);
+                received++;
+            }
+        }
+
+        return new MtrHop(ttl, replyAddr, null, rtts, sent, received);
+    }
+
+    /**
+     * Per-attempt timeout: divide the probe budget evenly across (1 + retryCount)
+     * attempts so we still honour probeTimeout overall.
+     */
+    private long computeAttemptTimeoutMs(MtrOptions options) {
+        long budget = options.getProbeTimeout().toMillis();
+        // Simple: each attempt gets an equal share
+        return Math.max(100L, budget / (options.getRetryCount() + 1));
+    }
+
+    /**
+     * Sends a single ICMP echo request and returns the result or {@code null} on
+     * timeout/no-reply.
+     */
+    @Nullable
+    private ProbeResult sendSingleProbe(InetAddress target, int ttl,
+                                        byte[] payload, int timeoutMs,
+                                        MtrOptions options) throws MtrException {
+        if (target instanceof Inet4Address) {
+            return sendProbeV4((Inet4Address) target, ttl, payload, timeoutMs, options);
+        } else {
+            return sendProbeV6((Inet6Address) target, ttl, payload, timeoutMs, options);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // IPv4 probe
+    // -------------------------------------------------------------------------
+
+    @Nullable
+    private ProbeResult sendProbeV4(Inet4Address target, int ttl,
+                                    byte[] payload, int timeoutMs,
+                                    MtrOptions options) throws MtrException {
+        try (Arena arena = Arena.ofConfined()) {
+            // Build IP_OPTION_INFORMATION
+            MemorySegment opts = arena.allocate(IcmpEchoReplyLayout.IP_OPTION_INFORMATION);
+            opts.set(ValueLayout.JAVA_BYTE,
+                     IcmpEchoReplyLayout.IP_OPT_OFFSET_TTL,
+                     (byte) ttl);
+            opts.set(ValueLayout.JAVA_BYTE,
+                     IcmpEchoReplyLayout.IP_OPT_OFFSET_TOS,
+                     (byte) options.tosToByte());
+
+            // Request payload
+            MemorySegment reqData = arena.allocate(payload.length == 0 ? 1 : payload.length);
+            MemorySegment.copy(payload, 0, reqData, ValueLayout.JAVA_BYTE, 0, payload.length);
+
+            // Reply buffer
+            int replyBufSize = IcmpEchoReplyLayout.IPV4_REPLY_BUFFER_SIZE
+                               + Math.max(0, payload.length - 56); // extra room for payload echo
+            MemorySegment replyBuf = arena.allocate(replyBufSize);
+
+            // Convert destination address to DWORD (big-endian int)
+            int dstAddrInt = bytesToInt(target.getAddress());
+
+            long tBefore = System.nanoTime();
+            int replies = IcmpLib.icmpSendEcho2Ex(
+                    icmpHandle4,
+                    0, dstAddrInt,          // src=any, dst
+                    reqData, (short) payload.length,
+                    opts,
+                    replyBuf, replyBufSize,
+                    timeoutMs);
+            long tAfter = System.nanoTime();
+
+            if (replies == 0) {
+                return null; // timeout or no reply
+            }
+
+            // Parse ICMP_ECHO_REPLY
+            int status = replyBuf.get(ValueLayout.JAVA_INT,
+                                      IcmpEchoReplyLayout.ECHO_REPLY_OFFSET_STATUS);
+
+            if (status == IcmpLib.IP_REQ_TIMED_OUT) {
+                return null;
+            }
+
+            // For MTR we accept both success (destination reached) and
+            // TTL-expired (intermediate hop).
+            if (status != IcmpLib.IP_SUCCESS
+                    && status != IcmpLib.IP_TTL_EXPIRED_TRANSIT
+                    && status != IcmpLib.IP_TTL_EXPIRED_REASSEM
+                    && status != IcmpLib.IP_DEST_NET_UNREACHABLE
+                    && status != IcmpLib.IP_DEST_HOST_UNREACHABLE
+                    && status != IcmpLib.IP_DEST_PORT_UNREACHABLE) {
+                log.trace("IcmpSendEcho2Ex status {} for TTL={}", status, ttl);
+                return null;
+            }
+
+            // Extract reply address
+            int addrInt = replyBuf.get(ValueLayout.JAVA_INT,
+                                       IcmpEchoReplyLayout.ECHO_REPLY_OFFSET_ADDRESS);
+            InetAddress from = InetAddress.getByAddress(intToBytes(addrInt));
+
+            // Prefer Windows-reported RTT but fall back to wall-clock
+            int rttMs = replyBuf.get(ValueLayout.JAVA_INT,
+                                     IcmpEchoReplyLayout.ECHO_REPLY_OFFSET_RTT);
+            Duration rtt = rttMs > 0
+                    ? Duration.ofMillis(rttMs)
+                    : Duration.ofNanos(tAfter - tBefore);
+
+            return new ProbeResult(from, rtt);
+        } catch (UnknownHostException e) {
+            throw new MtrException("Failed to parse reply address", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // IPv6 probe
+    // -------------------------------------------------------------------------
+
+    @Nullable
+    private ProbeResult sendProbeV6(Inet6Address target, int ttl,
+                                    byte[] payload, int timeoutMs,
+                                    MtrOptions options) throws MtrException {
+        if (icmpHandle6 == null) {
+            throw new MtrUnsupportedException("IPv6 ICMP handle not available");
+        }
+        try (Arena arena = Arena.ofConfined()) {
+            // Build IP_OPTION_INFORMATION (TTL = hop limit; TOS = DSCP for IPv6)
+            MemorySegment opts = arena.allocate(IcmpEchoReplyLayout.IP_OPTION_INFORMATION);
+            opts.set(ValueLayout.JAVA_BYTE,
+                     IcmpEchoReplyLayout.IP_OPT_OFFSET_TTL,
+                     (byte) ttl);
+            opts.set(ValueLayout.JAVA_BYTE,
+                     IcmpEchoReplyLayout.IP_OPT_OFFSET_TOS,
+                     (byte) options.tosToByte());
+
+            // Request payload
+            MemorySegment reqData = arena.allocate(Math.max(1, payload.length));
+            if (payload.length > 0) {
+                MemorySegment.copy(payload, 0, reqData, ValueLayout.JAVA_BYTE, 0, payload.length);
+            }
+
+            // Build sockaddr_in6 for destination
+            MemorySegment dstSockAddr = buildSockAddrIn6(arena, target.getAddress());
+            // Source: all-zeros (any interface)
+            MemorySegment srcSockAddr = arena.allocate(IcmpEchoReplyLayout.SOCKADDR_IN6_SIZE);
+            srcSockAddr.set(ValueLayout.JAVA_SHORT,
+                            IcmpEchoReplyLayout.SA6_OFFSET_FAMILY,
+                            IcmpEchoReplyLayout.AF_INET6);
+
+            // Reply buffer
+            int replyBufSize = IcmpEchoReplyLayout.IPV6_REPLY_BUFFER_SIZE;
+            MemorySegment replyBuf = arena.allocate(replyBufSize);
+
+            long tBefore = System.nanoTime();
+            int replies = IcmpLib.icmp6SendEcho2(
+                    icmpHandle6,
+                    srcSockAddr, dstSockAddr,
+                    reqData, (short) payload.length,
+                    opts,
+                    replyBuf, replyBufSize,
+                    timeoutMs);
+            long tAfter = System.nanoTime();
+
+            if (replies == 0) return null;
+
+            // Parse ICMPV6_ECHO_REPLY
+            int status = (int) Integer.toUnsignedLong(
+                    replyBuf.get(ValueLayout.JAVA_INT, IcmpEchoReplyLayout.ECHO6_STATUS_OFFSET));
+
+            if (status == IcmpLib.IP_REQ_TIMED_OUT) return null;
+            if (status != IcmpLib.IP_SUCCESS
+                    && status != IcmpLib.IP_TTL_EXPIRED_TRANSIT
+                    && status != IcmpLib.IP_TTL_EXPIRED_REASSEM) {
+                log.trace("Icmp6SendEcho2 status {} for TTL={}", status, ttl);
+                return null;
+            }
+
+            // Extract 16-byte IPv6 address
+            byte[] addrBytes = new byte[16];
+            MemorySegment.copy(replyBuf, ValueLayout.JAVA_BYTE,
+                               IcmpEchoReplyLayout.ECHO6_ADDR_OFFSET,
+                               addrBytes, 0, 16);
+            InetAddress from = InetAddress.getByAddress(addrBytes);
+
+            int rttMs = replyBuf.get(ValueLayout.JAVA_INT, IcmpEchoReplyLayout.ECHO6_RTT_OFFSET);
+            Duration rtt = rttMs > 0
+                    ? Duration.ofMillis(rttMs)
+                    : Duration.ofNanos(tAfter - tBefore);
+
+            return new ProbeResult(from, rtt);
+        } catch (UnknownHostException e) {
+            throw new MtrException("Failed to parse IPv6 reply address", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Hostname resolution (post-trace, uses standard Java DNS)
+    // -------------------------------------------------------------------------
+
+    private List<MtrHop> resolveHostnames(List<MtrHop> hops) {
+        // Use virtual threads to parallelize PTR lookups
+        try (ExecutorService ex = Executors.newVirtualThreadPerTaskExecutor()) {
+            List<Future<String>> futures = new ArrayList<>(hops.size());
+            for (MtrHop hop : hops) {
+                if (hop.getAddress() != null) {
+                    final InetAddress addr = hop.getAddress();
+                    futures.add(ex.submit(() -> {
+                        try {
+                            // getHostName() triggers a PTR lookup
+                            return InetAddress.getByAddress(addr.getAddress()).getHostName();
+                        } catch (Exception ignored) {
+                            return null;
+                        }
+                    }));
+                } else {
+                    futures.add(CompletableFuture.completedFuture(null));
+                }
+            }
+
+            List<MtrHop> resolved = new ArrayList<>(hops.size());
+            for (int i = 0; i < hops.size(); i++) {
+                MtrHop hop = hops.get(i);
+                String hostname = null;
+                try {
+                    hostname = futures.get(i).get(2, TimeUnit.SECONDS);
+                } catch (Exception ignored) {}
+
+                // If hostname == IP string, don't bother storing it
+                if (hostname != null && hop.getAddress() != null
+                        && hostname.equals(hop.getAddress().getHostAddress())) {
+                    hostname = null;
+                }
+
+                resolved.add(new MtrHop(
+                        hop.getTtl(), hop.getAddress(), hostname,
+                        hop.getRtts(), hop.getSent(), hop.getReceived()));
+            }
+            return resolved;
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    private static byte[] buildPayload(int size) {
+        byte[] buf = new byte[size];
+        // Fill with a recognisable pattern
+        for (int i = 0; i < size; i++) buf[i] = (byte) (i & 0xFF);
+        return buf;
+    }
+
+    private static MtrHop unresponsiveHop(int ttl, int probeCount) {
+        return new MtrHop(ttl, null, null, Collections.emptyList(), probeCount, 0);
+    }
+
+    /**
+     * Converts a 4-byte network-order (big-endian) address array to a
+     * Windows {@code IPAddr} DWORD (little-endian / host byte order on x86).
+     * e.g. 192.168.0.1 → bytes [192,168,0,1] → int 0x0100A8C0 (little-endian)
+     */
+    private static int bytesToInt(byte[] addr) {
+        // Windows IPAddr is stored in host (little-endian) byte order.
+        // addr[0] is the most-significant octet in dotted-decimal notation,
+        // which must become the least-significant byte of the DWORD.
+        return  (addr[0] & 0xFF)
+             | ((addr[1] & 0xFF) <<  8)
+             | ((addr[2] & 0xFF) << 16)
+             | ((addr[3] & 0xFF) << 24);
+    }
+
+    /**
+     * Converts a Windows {@code IPAddr} DWORD (little-endian) back to a
+     * 4-byte network-order (big-endian) array for {@link InetAddress#getByAddress}.
+     * e.g. int 0x0100A8C0 → bytes [192,168,0,1]
+     */
+    private static byte[] intToBytes(int addr) {
+        return new byte[]{
+                (byte)  addr,           // least-significant byte → first octet
+                (byte) (addr >>>  8),
+                (byte) (addr >>> 16),
+                (byte) (addr >>> 24)    // most-significant byte  → last octet
+        };
+    }
+
+    /**
+     * Allocates and fills a {@code sockaddr_in6} structure in the given arena.
+     *
+     * @param arena    the arena to allocate from
+     * @param addrBytes 16-byte IPv6 address (network byte order)
+     */
+    private static MemorySegment buildSockAddrIn6(Arena arena, byte[] addrBytes) {
+        MemorySegment seg = arena.allocate(IcmpEchoReplyLayout.SOCKADDR_IN6_SIZE);
+        seg.set(ValueLayout.JAVA_SHORT,
+                IcmpEchoReplyLayout.SA6_OFFSET_FAMILY,
+                IcmpEchoReplyLayout.AF_INET6);
+        seg.set(ValueLayout.JAVA_SHORT, IcmpEchoReplyLayout.SA6_OFFSET_PORT, (short) 0);
+        seg.set(ValueLayout.JAVA_INT,   IcmpEchoReplyLayout.SA6_OFFSET_FLOWINFO, 0);
+        MemorySegment.copy(addrBytes, 0, seg, ValueLayout.JAVA_BYTE,
+                           IcmpEchoReplyLayout.SA6_OFFSET_ADDR, 16);
+        seg.set(ValueLayout.JAVA_INT, IcmpEchoReplyLayout.SA6_OFFSET_SCOPE_ID, 0);
+        return seg;
+    }
+
+    // -------------------------------------------------------------------------
+    // Inner result carrier
+    // -------------------------------------------------------------------------
+
+    private record ProbeResult(InetAddress from, Duration rtt) {}
+}
+
+
+
+
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrHop.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrHop.java
@@ -1,0 +1,141 @@
+package com.ghostchu.peerbanhelper.platform.mtr;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Represents the result of a single hop in an MTR traceroute.
+ *
+ * <p><b>Loss-rate semantics:</b><br>
+ * {@code lossRate = (sent - received) / (double) sent}.
+ * A hop that never responded (all probes timed out after retries) will have an
+ * empty {@code rtts} list and {@code lossRate == 1.0}.
+ */
+public final class MtrHop {
+
+    /** 1-based TTL for this hop. */
+    private final int ttl;
+
+    /**
+     * Address of the router that responded, or {@code null} if this hop timed
+     * out for all probes (i.e., a {@code * * *} hop).
+     */
+    @Nullable
+    private final InetAddress address;
+
+    /**
+     * Reverse-DNS hostname of {@link #address}, populated only when
+     * {@link MtrOptions#isResolveHostnames()} is {@code true} and DNS lookup
+     * succeeded.  May be {@code null}.
+     */
+    @Nullable
+    private final String hostname;
+
+    /**
+     * RTT values for every probe that received a reply.  Empty when the hop is
+     * completely unresponsive.  The list is unmodifiable.
+     */
+    @NotNull
+    private final List<Duration> rtts;
+
+    /** Total number of probes sent for this hop (equals {@code probeCount}). */
+    private final int sent;
+
+    /** Number of probes that received a reply within the timeout. */
+    private final int received;
+
+    /** Fraction of lost probes: {@code (sent - received) / (double) sent}. */
+    private final double lossRate;
+
+    public MtrHop(int ttl,
+                  @Nullable InetAddress address,
+                  @Nullable String hostname,
+                  @NotNull List<Duration> rtts,
+                  int sent,
+                  int received) {
+        if (sent < 0) throw new IllegalArgumentException("sent must be >= 0");
+        if (received < 0 || received > sent)
+            throw new IllegalArgumentException("received must be in [0, sent]");
+        this.ttl      = ttl;
+        this.address  = address;
+        this.hostname = hostname;
+        this.rtts     = Collections.unmodifiableList(rtts);
+        this.sent     = sent;
+        this.received = received;
+        this.lossRate = (sent == 0) ? 0.0 : (double) (sent - received) / sent;
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public int getTtl()                         { return ttl;      }
+    public @Nullable InetAddress getAddress()   { return address;  }
+    public @Nullable String getHostname()       { return hostname; }
+    public @NotNull List<Duration> getRtts()    { return rtts;     }
+    public int getSent()                        { return sent;     }
+    public int getReceived()                    { return received; }
+    public double getLossRate()                 { return lossRate; }
+
+    /**
+     * Returns the minimum RTT across successful probes, or {@link Duration#ZERO}
+     * if no reply was received.
+     */
+    @NotNull
+    public Duration getMinRtt() {
+        return rtts.stream().min(Duration::compareTo).orElse(Duration.ZERO);
+    }
+
+    /**
+     * Returns the maximum RTT across successful probes, or {@link Duration#ZERO}
+     * if no reply was received.
+     */
+    @NotNull
+    public Duration getMaxRtt() {
+        return rtts.stream().max(Duration::compareTo).orElse(Duration.ZERO);
+    }
+
+    /**
+     * Returns the arithmetic mean RTT across successful probes, or
+     * {@link Duration#ZERO} if no reply was received.
+     */
+    @NotNull
+    public Duration getAvgRtt() {
+        if (rtts.isEmpty()) return Duration.ZERO;
+        long totalNanos = rtts.stream().mapToLong(Duration::toNanos).sum();
+        return Duration.ofNanos(totalNanos / rtts.size());
+    }
+
+    /** {@code true} if this hop never responded (all probes lost). */
+    public boolean isUnresponsive() {
+        return address == null;
+    }
+
+    /**
+     * Best display name: hostname if available, otherwise IP string, or
+     * {@code "*"} for unresponsive hops.
+     */
+    @NotNull
+    public String getDisplayName() {
+        if (address == null) return "*";
+        if (hostname != null && !hostname.isBlank()) return hostname;
+        return address.getHostAddress();
+    }
+
+    @Override
+    public String toString() {
+        return String.format("MtrHop{ttl=%d, addr=%s, sent=%d, recv=%d, loss=%.1f%%, avgRtt=%s}",
+                ttl,
+                getDisplayName(),
+                sent,
+                received,
+                lossRate * 100,
+                getAvgRtt());
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrOptions.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrOptions.java
@@ -1,0 +1,274 @@
+package com.ghostchu.peerbanhelper.platform.mtr;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.time.Duration;
+
+/**
+ * Configuration options for a single MTR (My Traceroute) trace operation.
+ *
+ * <p>Use {@link Builder} to construct instances with explicit or default values.
+ *
+ * <h3>Probe / retry semantics</h3>
+ * <ul>
+ *   <li>{@code probeCount} – number of independent probe rounds sent per hop
+ *       (determines denominator for loss-rate calculation).</li>
+ *   <li>{@code retryCount} – extra retry attempts when a single probe receives
+ *       no reply within {@code probeTimeout}. Only a probe that is still
+ *       unanswered after all retries counts as <em>lost</em>.
+ *       Maximum packets sent per hop = {@code probeCount × (1 + retryCount)}.</li>
+ * </ul>
+ *
+ * <h3>Example</h3>
+ * <pre>{@code
+ * MtrOptions opts = MtrOptions.builder()
+ *         .maxHops(30)
+ *         .probeCount(3)
+ *         .retryCount(2)
+ *         .probeTimeout(Duration.ofSeconds(1))
+ *         .totalTimeout(Duration.ofSeconds(60))
+ *         .payloadSize(56)
+ *         .resolveHostnames(false)
+ *         .dscp(0)
+ *         .build();
+ * }</pre>
+ */
+public final class MtrOptions {
+
+    // -------------------------------------------------------------------------
+    // Fields
+    // -------------------------------------------------------------------------
+
+    /** Maximum TTL / hop count before stopping the trace. Default: {@code 30}. */
+    private final int maxHops;
+
+    /**
+     * Number of probe packets sent per hop (used as denominator for loss-rate).
+     * Default: {@code 3}.
+     */
+    private final int probeCount;
+
+    /**
+     * Number of extra retry attempts when a probe receives no reply within
+     * {@link #probeTimeout}. Default: {@code 2}.
+     *
+     * <p>Setting this to {@code 0} disables retries; a non-responding hop is
+     * immediately counted as lost after one timeout.
+     */
+    private final int retryCount;
+
+    /**
+     * Per-probe timeout (including all retry rounds).  The effective wait per
+     * probe attempt is {@code probeTimeout / (1 + retryCount)}.
+     * Default: {@code 1 s}.
+     */
+    private final Duration probeTimeout;
+
+    /**
+     * Hard upper bound on the total time the trace may run.  When exceeded,
+     * {@link com.ghostchu.peerbanhelper.platform.mtr.exception.MtrTimeoutException}
+     * is thrown.  Default: {@code 60 s}.
+     */
+    private final Duration totalTimeout;
+
+    /**
+     * ICMP payload size in bytes (excluding IP and ICMP headers).
+     * Default: {@code 56} bytes (same as the classic {@code ping} default).
+     */
+    private final int payloadSize;
+
+    /**
+     * When {@code true}, each responding hop address is resolved to a hostname
+     * via reverse-DNS (PTR) lookup.  Results are stored in
+     * {@link MtrHop#getHostname()}.  Default: {@code false}.
+     */
+    private final boolean resolveHostnames;
+
+    /**
+     * IP DSCP value (6 bits, 0–63) placed in the TOS / Traffic Class byte.
+     * Default: {@code 0} (best-effort).
+     */
+    private final int dscp;
+
+    // -------------------------------------------------------------------------
+    // Constructor (private — use Builder)
+    // -------------------------------------------------------------------------
+
+    private MtrOptions(Builder b) {
+        this.maxHops          = b.maxHops;
+        this.probeCount       = b.probeCount;
+        this.retryCount       = b.retryCount;
+        this.probeTimeout     = b.probeTimeout;
+        this.totalTimeout     = b.totalTimeout;
+        this.payloadSize      = b.payloadSize;
+        this.resolveHostnames = b.resolveHostnames;
+        this.dscp             = b.dscp;
+    }
+
+    // -------------------------------------------------------------------------
+    // Factory
+    // -------------------------------------------------------------------------
+
+    /** Returns a {@link Builder} pre-filled with recommended defaults. */
+    @NotNull
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /** Returns a {@link MtrOptions} instance with all defaults applied. */
+    @NotNull
+    public static MtrOptions defaults() {
+        return builder().build();
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public int getMaxHops()              { return maxHops;          }
+    public int getProbeCount()           { return probeCount;       }
+    public int getRetryCount()           { return retryCount;       }
+    public @NotNull Duration getProbeTimeout()  { return probeTimeout;    }
+    public @NotNull Duration getTotalTimeout()  { return totalTimeout;    }
+    public int getPayloadSize()          { return payloadSize;      }
+    public boolean isResolveHostnames()  { return resolveHostnames; }
+    public int getDscp()                 { return dscp;             }
+
+    /**
+     * Converts {@link #dscp} to the 8-bit TOS / Traffic Class byte
+     * ({@code dscp << 2}).
+     */
+    public int tosToByte() {
+        return (dscp & 0x3F) << 2;
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    private void validate() {
+        if (maxHops < 1 || maxHops > 255)
+            throw new IllegalArgumentException("maxHops must be in [1, 255], got " + maxHops);
+        if (probeCount < 1)
+            throw new IllegalArgumentException("probeCount must be >= 1, got " + probeCount);
+        if (retryCount < 0)
+            throw new IllegalArgumentException("retryCount must be >= 0, got " + retryCount);
+        if (probeTimeout == null || probeTimeout.isNegative() || probeTimeout.isZero())
+            throw new IllegalArgumentException("probeTimeout must be positive");
+        if (totalTimeout == null || totalTimeout.isNegative() || totalTimeout.isZero())
+            throw new IllegalArgumentException("totalTimeout must be positive");
+        if (payloadSize < 0 || payloadSize > 65507)
+            throw new IllegalArgumentException("payloadSize must be in [0, 65507], got " + payloadSize);
+        if (dscp < 0 || dscp > 63)
+            throw new IllegalArgumentException("dscp must be in [0, 63], got " + dscp);
+    }
+
+    // -------------------------------------------------------------------------
+    // Builder
+    // -------------------------------------------------------------------------
+
+    public static final class Builder {
+
+        private int      maxHops          = 30;
+        private int      probeCount       = 3;
+        private int      retryCount       = 2;
+        private Duration probeTimeout     = Duration.ofSeconds(1);
+        private Duration totalTimeout     = Duration.ofSeconds(60);
+        private int      payloadSize      = 56;
+        private boolean  resolveHostnames = false;
+        private int      dscp             = 0;
+
+        private Builder() {}
+
+        /**
+         * Maximum TTL / hop count (1–255).  Default: {@code 30}.
+         */
+        public Builder maxHops(int maxHops) {
+            this.maxHops = maxHops;
+            return this;
+        }
+
+        /**
+         * Number of probes sent per hop.  Determines the loss-rate denominator.
+         * Default: {@code 3}.
+         */
+        public Builder probeCount(int probeCount) {
+            this.probeCount = probeCount;
+            return this;
+        }
+
+        /**
+         * Extra retries per probe attempt on no-reply.  {@code 0} = no retry.
+         * Default: {@code 2}.
+         */
+        public Builder retryCount(int retryCount) {
+            this.retryCount = retryCount;
+            return this;
+        }
+
+        /**
+         * Timeout applied to each individual probe send+receive cycle.
+         * Default: {@code 1 s}.
+         */
+        public Builder probeTimeout(Duration probeTimeout) {
+            this.probeTimeout = probeTimeout;
+            return this;
+        }
+
+        /**
+         * Hard total-trace timeout.  Default: {@code 60 s}.
+         */
+        public Builder totalTimeout(Duration totalTimeout) {
+            this.totalTimeout = totalTimeout;
+            return this;
+        }
+
+        /**
+         * ICMP echo payload size in bytes (0–65507).  Default: {@code 56}.
+         */
+        public Builder payloadSize(int payloadSize) {
+            this.payloadSize = payloadSize;
+            return this;
+        }
+
+        /**
+         * Enable reverse-DNS hostname resolution per hop.  Default: {@code false}.
+         */
+        public Builder resolveHostnames(boolean resolveHostnames) {
+            this.resolveHostnames = resolveHostnames;
+            return this;
+        }
+
+        /**
+         * IP DSCP field value (0–63).  Default: {@code 0} (best-effort).
+         */
+        public Builder dscp(int dscp) {
+            this.dscp = dscp;
+            return this;
+        }
+
+        /** Validates and builds the {@link MtrOptions} instance. */
+        @NotNull
+        public MtrOptions build() {
+            MtrOptions opts = new MtrOptions(this);
+            opts.validate();
+            return opts;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "MtrOptions{" +
+               "maxHops=" + maxHops +
+               ", probeCount=" + probeCount +
+               ", retryCount=" + retryCount +
+               ", probeTimeout=" + probeTimeout +
+               ", totalTimeout=" + totalTimeout +
+               ", payloadSize=" + payloadSize +
+               ", resolveHostnames=" + resolveHostnames +
+               ", dscp=" + dscp +
+               '}';
+    }
+}
+
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrResult.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/MtrResult.java
@@ -1,0 +1,95 @@
+package com.ghostchu.peerbanhelper.platform.mtr;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * The complete result of an MTR (My Traceroute) operation.
+ */
+public final class MtrResult {
+
+    /** The destination address that was traced. */
+    @NotNull
+    private final InetAddress target;
+
+    /**
+     * Ordered list of hops, index 0 = TTL 1 (first router after the local
+     * host).  The list is unmodifiable.
+     */
+    @NotNull
+    private final List<MtrHop> hops;
+
+    /** Wall-clock time when the trace was initiated. */
+    @NotNull
+    private final Instant startTime;
+
+    /** Total elapsed time from trace start to completion. */
+    @NotNull
+    private final Duration totalElapsed;
+
+    public MtrResult(@NotNull InetAddress target,
+                     @NotNull List<MtrHop> hops,
+                     @NotNull Instant startTime,
+                     @NotNull Duration totalElapsed) {
+        this.target       = target;
+        this.hops         = Collections.unmodifiableList(hops);
+        this.startTime    = startTime;
+        this.totalElapsed = totalElapsed;
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    public @NotNull InetAddress getTarget()        { return target;       }
+    public @NotNull List<MtrHop> getHops()         { return hops;         }
+    public @NotNull Instant getStartTime()         { return startTime;    }
+    public @NotNull Duration getTotalElapsed()     { return totalElapsed; }
+
+    /** Number of hops in the trace result. */
+    public int getHopCount() { return hops.size(); }
+
+    /**
+     * Overall packet-loss rate averaged across all hops that had at least one
+     * sent probe.
+     */
+    public double getOverallLossRate() {
+        if (hops.isEmpty()) return 0.0;
+        return hops.stream()
+                   .filter(h -> h.getSent() > 0)
+                   .mapToDouble(MtrHop::getLossRate)
+                   .average()
+                   .orElse(0.0);
+    }
+
+    /**
+     * Whether the trace actually reached the target (i.e., the last hop that
+     * responded has the same address as {@link #target}).
+     */
+    public boolean reachedTarget() {
+        for (int i = hops.size() - 1; i >= 0; i--) {
+            InetAddress addr = hops.get(i).getAddress();
+            if (addr != null) {
+                return addr.equals(target);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(String.format("MtrResult{target=%s, hops=%d, elapsed=%s, reachedTarget=%b}%n",
+                target.getHostAddress(), hops.size(), totalElapsed, reachedTarget()));
+        for (MtrHop hop : hops) {
+            sb.append("  ").append(hop).append(System.lineSeparator());
+        }
+        return sb.toString();
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrException.java
@@ -1,0 +1,16 @@
+package com.ghostchu.peerbanhelper.platform.mtr.exception;
+
+/**
+ * Base checked exception for all MTR (My Traceroute) errors.
+ */
+public class MtrException extends Exception {
+
+    public MtrException(String message) {
+        super(message);
+    }
+
+    public MtrException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrPermissionException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrPermissionException.java
@@ -1,0 +1,32 @@
+package com.ghostchu.peerbanhelper.platform.mtr.exception;
+
+/**
+ * Thrown when the current process lacks the privileges needed to create a
+ * raw/ICMP socket (errno EPERM / EACCES on POSIX, or equivalent on Windows).
+ */
+public class MtrPermissionException extends MtrException {
+
+    /** Platform-specific error code (errno on POSIX, WSAGetLastError on Windows). */
+    private final int errorCode;
+
+    public MtrPermissionException(String message, int errorCode) {
+        super(message);
+        this.errorCode = errorCode;
+    }
+
+    public MtrPermissionException(String message, int errorCode, Throwable cause) {
+        super(message, cause);
+        this.errorCode = errorCode;
+    }
+
+    /** @return platform error code that caused this exception */
+    public int getErrorCode() {
+        return errorCode;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "[errorCode=" + errorCode + "]: " + getMessage();
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrTimeoutException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrTimeoutException.java
@@ -1,0 +1,16 @@
+package com.ghostchu.peerbanhelper.platform.mtr.exception;
+
+/**
+ * Thrown when the overall MTR trace exceeds {@code MtrOptions.totalTimeout}.
+ */
+public class MtrTimeoutException extends MtrException {
+
+    public MtrTimeoutException(String message) {
+        super(message);
+    }
+
+    public MtrTimeoutException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrUnsupportedException.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/mtr/exception/MtrUnsupportedException.java
@@ -1,0 +1,17 @@
+package com.ghostchu.peerbanhelper.platform.mtr.exception;
+
+/**
+ * Thrown when the current platform or address family (IPv4/IPv6) is not
+ * supported for ICMP tracing.
+ */
+public class MtrUnsupportedException extends MtrException {
+
+    public MtrUnsupportedException(String message) {
+        super(message);
+    }
+
+    public MtrUnsupportedException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+

--- a/src/main/java/com/ghostchu/peerbanhelper/platform/types/MtrTool.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/platform/types/MtrTool.java
@@ -1,0 +1,45 @@
+package com.ghostchu.peerbanhelper.platform.types;
+
+import com.ghostchu.peerbanhelper.platform.mtr.MtrOptions;
+import com.ghostchu.peerbanhelper.platform.mtr.MtrResult;
+import com.ghostchu.peerbanhelper.platform.mtr.exception.MtrException;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetAddress;
+
+/**
+ * Platform-aware MTR (My Traceroute) tool using ICMP probes.
+ *
+ * <p>Implementations are required to:
+ * <ul>
+ *   <li>Support parallel TTL probing for performance.</li>
+ *   <li>Honour {@link MtrOptions#getRetryCount()} to reduce false packet-loss.</li>
+ *   <li>Throw the appropriate {@link MtrException} subclass on errors.</li>
+ * </ul>
+ */
+public interface MtrTool {
+
+    /**
+     * Runs a full MTR trace to {@code target}.
+     *
+     * @param target  destination address (IPv4 or IPv6)
+     * @param options tuning parameters
+     * @return the complete trace result
+     * @throws MtrException (or any sub-class) on any failure
+     */
+    @NotNull
+    MtrResult trace(@NotNull InetAddress target, @NotNull MtrOptions options) throws MtrException;
+
+    /**
+     * Returns {@code true} if this implementation can trace the given address
+     * on the current platform without throwing an unsupported exception.
+     * <p>
+     * Callers should check this before invoking {@link #trace} to provide a
+     * meaningful error message to the user.
+     *
+     * @param target the address to check
+     * @return {@code true} if tracing is expected to work
+     */
+    boolean isSupported(@NotNull InetAddress target);
+}
+


### PR DESCRIPTION
该 PR 向 dev 分支拉取实验性 Native MTR 支持，通过 FFM API 与系统 API 通信，构建 ICMP 包，对特定 IP 地址进行 MTR 探测。

<img width="1810" height="496" alt="008bd98d80dad25dfb376551cc755b78" src="https://github.com/user-attachments/assets/977b2420-11d4-40e8-937d-0f5af436d91e" />

## 概述

尽管刷流的恶意 Peer 可以自由更换其地址，横跨多 IP 段，但实际路由情况针对同一家族的同一地域下的 Peer 总是表现出十分惊人的相似性（特别是靠近终端的最后数跳）。这使得通过机器学习分辨是否为恶意 Peer 成为可能。

通过 MTR 测定，还可以得到到达目标 IP 地址的跃点数和延迟信息，通过跃点数和延迟标准差等信息，可以进一步推断指定 IP 地址是否处于省级骨干节点或者骨干网边缘。通常跃点数较少代表其越靠近骨干网。而公众宽带（如家宽、智企、智企+等）通常需要更多跃点数。

同时 MTR 提供的延迟数据可以根据延迟标准差等信息判断其延迟稳定性。如果延迟过于稳定，则通常属于高 QoS 等级网络，也可能为商业用途网或数据中心网络。

与 IPV6 配合使用则还可以更加详细观测其网络拓扑结构：

<img width="1708" height="459" alt="image" src="https://github.com/user-attachments/assets/a00ab974-c92a-456a-8772-d5a28229aa7b" />

以上种种特征提供了比 BT 协议本身更加丰富的特征信息，使得机器学习成为可能。附加 BTN 数据则可以完成无监督训练。此外，对于禁止 ICMP 的，没有特征也是一种特征。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 发行说明

* **新功能**
  * 添加了 ICMP 网络路由追踪功能，用于诊断网络连接路径
  * 在 Linux、macOS 和 Windows 平台上启用路由追踪支持
  * 优化了非 Windows 系统的平台识别机制

<!-- end of auto-generated comment: release notes by coderabbit.ai -->