### PR TITLE
AutoRangeBan/PCB/MDB: 解析 Teredo 内嵌 IPv4 以避免误封

### DIFF
--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -25,6 +25,11 @@ public final class ProfileUpdateScript {
         this.conf = conf;
     }
 
+    @UpdateScript(version = 41)
+    public void addAutoRangeBanTeredoMode() {
+        conf.set("module.auto-range-ban.teredo", "parse");
+    }
+
     @UpdateScript(version = 40)
     public void addGopeedExpRules() {
         List<String> bannedClientNames = conf.getStringList("module.client-name-blacklist.banned-client-name");

--- a/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/ProfileUpdateScript.java
@@ -26,8 +26,10 @@ public final class ProfileUpdateScript {
     }
 
     @UpdateScript(version = 41)
-    public void addAutoRangeBanTeredoMode() {
+    public void addTeredoMode() {
         conf.set("module.auto-range-ban.teredo", "parse");
+        conf.set("module.progress-cheat-blocker.teredo", "parse");
+        conf.set("module.multi-dialing-blocker.teredo", "parse");
     }
 
     @UpdateScript(version = 40)

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -21,6 +21,7 @@ import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
+import inet.ipaddr.ipv4.IPv4Address;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -110,7 +111,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             peerAddress = peerAddress.toIPv4();
         }
         if (isTeredo(peerAddress)) {
-            return pass();
+            peerAddress = extractTeredoIPv4(peerAddress);
         }
         AtomicReference<CheckResult> reference = new AtomicReference<>(null);
         IPAddress finalPeerAddress = peerAddress;
@@ -122,21 +123,22 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             if (bannedMeta.isBanForDisconnect()) {
                 return;
             }
+            IPAddress effectiveBannedAddr = bannedAddr;
             if (isTeredo(bannedAddr)) {
-                return;
+                effectiveBannedAddr = extractTeredoIPv4(bannedAddr);
             }
-            if (finalPeerAddress.isIPv4() != bannedAddr.isIPv4()) {
+            if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
                 return;
             }
             String addressType = "UNKNOWN";
-            IPAddress bannedCidr = bannedAddr;
-            if (bannedAddr.isIPv4()) {
+            IPAddress bannedCidr = effectiveBannedAddr;
+            if (effectiveBannedAddr.isIPv4()) {
                 addressType = "IPv4/" + ipv4Prefix;
-                bannedCidr = bannedAddr.toPrefixBlock(ipv4Prefix);
+                bannedCidr = effectiveBannedAddr.toPrefixBlock(ipv4Prefix);
             }
-            if (bannedAddr.isIPv6()) {
+            if (effectiveBannedAddr.isIPv6()) {
                 addressType = "IPv6/" + ipv6Prefix;
-                bannedCidr = bannedAddr.toPrefixBlock(ipv6Prefix);
+                bannedCidr = effectiveBannedAddr.toPrefixBlock(ipv6Prefix);
             }
             if (bannedCidr.contains(finalPeerAddress)) {
                 reference.set(new CheckResult(getClass(), PeerAction.BAN, banDuration, new TranslationComponent(addressType), new TranslationComponent(Lang.ARB_BANNED, finalPeerAddress.toString(),
@@ -150,6 +152,15 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
 
     private static boolean isTeredo(IPAddress address) {
         return address.isIPv6() && TEREDO_PREFIX.contains(address);
+    }
+
+    private static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
+        byte[] bytes = teredoAddress.getBytes();
+        byte[] ipv4Bytes = new byte[4];
+        for (int i = 0; i < 4; i++) {
+            ipv4Bytes[i] = (byte) (~bytes[12 + i]);
+        }
+        return new IPv4Address(ipv4Bytes);
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -148,7 +148,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             }
             if (bannedCidr.contains(finalPeerAddress)) {
                 StructuredData structuredData = StructuredData.create()
-                        .add("relatedBannedAddress", bannedAddr.toCompressedString());
+                        .add("relatedBannedAddress", resolvedAddr.toCompressedString());
                 if (isTeredo(bannedAddr)) {
                     structuredData.add("teredoMode", teredoMode)
                             .add("originalBannedAddress", bannedAddr.toCompressedString());

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -131,7 +131,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
                     return;
                 }
                 Integer prefixLen = bannedAddr.getPrefixLength();
-                if (prefixLen != null && prefixLen < 128) {
+                if (bannedAddr.isMultiple() || (prefixLen != null && prefixLen < 128)) {
                     return;
                 }
                 effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
@@ -164,12 +164,8 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     }
 
     private static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
-        byte[] bytes = teredoAddress.getBytes();
-        byte[] ipv4Bytes = new byte[4];
-        for (int i = 0; i < 4; i++) {
-            ipv4Bytes[i] = (byte) (~bytes[12 + i]);
-        }
-        return new IPv4Address(ipv4Bytes);
+        IPv4Address encodedIPv4 = teredoAddress.toIPv6().getEmbeddedIPv4Address();
+        return new IPv4Address(~encodedIPv4.intValue());
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -20,6 +20,7 @@ import com.ghostchu.peerbanhelper.wrapper.StructuredData;
 import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
 import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -33,6 +34,7 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 @Component
 public final class AutoRangeBan extends AbstractRuleFeatureModule implements Reloadable {
+    private static final IPAddress TEREDO_PREFIX = new IPAddressString("2001::/32").getAddress();
     @Autowired
     private PeerBanHelper peerBanHelper;
     private int ipv4Prefix;
@@ -107,6 +109,9 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
         if (peerAddress.isIPv4Convertible()) {
             peerAddress = peerAddress.toIPv4();
         }
+        if (isTeredo(peerAddress)) {
+            return pass();
+        }
         AtomicReference<CheckResult> reference = new AtomicReference<>(null);
         IPAddress finalPeerAddress = peerAddress;
         task.setComment(false, "Iterating banList for related ban entries.");
@@ -115,6 +120,9 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
                 return;
             }
             if (bannedMeta.isBanForDisconnect()) {
+                return;
+            }
+            if (isTeredo(bannedAddr)) {
                 return;
             }
             if (finalPeerAddress.isIPv4() != bannedAddr.isIPv4()) {
@@ -140,5 +148,8 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
         return Objects.requireNonNullElseGet(result, this::pass);
     }
 
+    private static boolean isTeredo(IPAddress address) {
+        return address.isIPv6() && TEREDO_PREFIX.contains(address);
+    }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -107,9 +107,11 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             return pass();
         }
         IPAddress peerAddress = peer.getPeerAddress().getAddress().withoutPrefixLength();
-        peerAddress = resolveTeredo(peerAddress);
-        if (peerAddress == null) {
-            return pass();
+        if (isTeredo(peerAddress)) {
+            peerAddress = resolveTeredo(peerAddress);
+            if (peerAddress == null) {
+                return pass();
+            }
         }
         if (peerAddress.isIPv4Convertible()) {
             peerAddress = peerAddress.toIPv4();
@@ -124,9 +126,12 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             if (bannedMeta.isBanForDisconnect()) {
                 return;
             }
-            IPAddress resolvedAddr = resolveTeredo(bannedAddr);
-            if (resolvedAddr == null) {
-                return;
+            IPAddress resolvedAddr = bannedAddr;
+            if (isTeredo(bannedAddr)) {
+                resolvedAddr = resolveTeredo(bannedAddr);
+                if (resolvedAddr == null) {
+                    return;
+                }
             }
             if (finalPeerAddress.isIPv4() != resolvedAddr.isIPv4()) {
                 return;
@@ -158,25 +163,22 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     }
 
     /**
-     * 根据 teredoMode 配置解析 Teredo 地址。
+     * 根据 teredoMode 配置解析 Teredo 地址，调用前应先用 isTeredo() 判断。
      * 返回 null 表示应跳过该地址（skip 模式或不可解析的前缀块）；
-     * 返回原地址表示非 Teredo 或 original 模式；
+     * 返回原地址表示 original 模式；
      * 返回提取的 IPv4 表示 parse 模式。
      */
-    private IPAddress resolveTeredo(IPAddress address) {
-        if (!isTeredo(address)) {
-            return address;
-        }
+    private IPAddress resolveTeredo(IPAddress teredoAddress) {
         return switch (teredoMode) {
             case "skip" -> null;
             case "parse" -> {
-                Integer prefixLen = address.getPrefixLength();
-                if (address.isMultiple() || (prefixLen != null && prefixLen < 128)) {
+                Integer prefixLen = teredoAddress.getPrefixLength();
+                if (teredoAddress.isMultiple() || (prefixLen != null && prefixLen < 128)) {
                     yield null;
                 }
-                yield extractTeredoIPv4(address.withoutPrefixLength());
+                yield extractTeredoIPv4(teredoAddress.withoutPrefixLength());
             }
-            default -> address;
+            default -> teredoAddress;
         };
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -107,16 +107,11 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             return pass();
         }
         IPAddress peerAddress = peer.getPeerAddress().getAddress().withoutPrefixLength();
-        if (isTeredo(peerAddress)) {
-            switch (teredoMode) {
-                case "skip" -> {
-                    return pass();
-                }
-                case "parse" -> peerAddress = extractTeredoIPv4(peerAddress);
-                default -> {
-                }
-            }
-        } else if (peerAddress.isIPv4Convertible()) {
+        peerAddress = resolveTeredo(peerAddress);
+        if (peerAddress == null) {
+            return pass();
+        }
+        if (peerAddress.isIPv4Convertible()) {
             peerAddress = peerAddress.toIPv4();
         }
         AtomicReference<CheckResult> reference = new AtomicReference<>(null);
@@ -129,44 +124,60 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             if (bannedMeta.isBanForDisconnect()) {
                 return;
             }
-            IPAddress effectiveBannedAddr = bannedAddr;
-            if (isTeredo(bannedAddr)) {
-                switch (teredoMode) {
-                    case "skip" -> {
-                        return;
-                    }
-                    case "parse" -> {
-                        Integer prefixLen = bannedAddr.getPrefixLength();
-                        if (bannedAddr.isMultiple() || (prefixLen != null && prefixLen < 128)) {
-                            return;
-                        }
-                        effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
-                    }
-                    default -> {
-                    }
-                }
+            IPAddress resolvedAddr = resolveTeredo(bannedAddr);
+            if (resolvedAddr == null) {
+                return;
             }
-            if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
+            if (finalPeerAddress.isIPv4() != resolvedAddr.isIPv4()) {
                 return;
             }
             String addressType = "UNKNOWN";
-            IPAddress bannedCidr = effectiveBannedAddr;
-            if (effectiveBannedAddr.isIPv4()) {
+            IPAddress bannedCidr = resolvedAddr;
+            if (resolvedAddr.isIPv4()) {
                 addressType = "IPv4/" + ipv4Prefix;
-                bannedCidr = effectiveBannedAddr.toPrefixBlock(ipv4Prefix);
+                bannedCidr = resolvedAddr.toPrefixBlock(ipv4Prefix);
             }
-            if (effectiveBannedAddr.isIPv6()) {
+            if (resolvedAddr.isIPv6()) {
                 addressType = "IPv6/" + ipv6Prefix;
-                bannedCidr = effectiveBannedAddr.toPrefixBlock(ipv6Prefix);
+                bannedCidr = resolvedAddr.toPrefixBlock(ipv6Prefix);
             }
             if (bannedCidr.contains(finalPeerAddress)) {
+                StructuredData structuredData = StructuredData.create()
+                        .add("relatedBannedAddress", bannedAddr.toCompressedString());
+                if (isTeredo(bannedAddr)) {
+                    structuredData.add("teredoMode", teredoMode)
+                            .add("originalBannedAddress", bannedAddr.toCompressedString());
+                }
                 reference.set(new CheckResult(getClass(), PeerAction.BAN, banDuration, new TranslationComponent(addressType), new TranslationComponent(Lang.ARB_BANNED, finalPeerAddress.toString(),
                         bannedAddr.toString(), bannedCidr.toString(), addressType),
-                        StructuredData.create().add("relatedBannedAddress", bannedAddr.toCompressedString())));
+                        structuredData));
             }
         });
         var result = reference.get();
         return Objects.requireNonNullElseGet(result, this::pass);
+    }
+
+    /**
+     * 根据 teredoMode 配置解析 Teredo 地址。
+     * 返回 null 表示应跳过该地址（skip 模式或不可解析的前缀块）；
+     * 返回原地址表示非 Teredo 或 original 模式；
+     * 返回提取的 IPv4 表示 parse 模式。
+     */
+    private IPAddress resolveTeredo(IPAddress address) {
+        if (!isTeredo(address)) {
+            return address;
+        }
+        return switch (teredoMode) {
+            case "skip" -> null;
+            case "parse" -> {
+                Integer prefixLen = address.getPrefixLength();
+                if (address.isMultiple() || (prefixLen != null && prefixLen < 128)) {
+                    yield null;
+                }
+                yield extractTeredoIPv4(address.withoutPrefixLength());
+            }
+            default -> address;
+        };
     }
 
     private static boolean isTeredo(IPAddress address) {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -38,7 +38,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     private PeerBanHelper peerBanHelper;
     private int ipv4Prefix;
     private int ipv6Prefix;
-    private boolean teredoEnabled;
+    private String teredoMode;
     @Autowired
     private JavalinWebContainer webContainer;
     private long banDuration;
@@ -82,7 +82,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     }
 
     private void handleWebAPI(Context ctx) {
-        ctx.json(new StdResp(true, null, Map.of("ipv4-prefix", ipv4Prefix, "ipv6-prefix", ipv6Prefix, "teredo", teredoEnabled)));
+        ctx.json(new StdResp(true, null, Map.of("ipv4-prefix", ipv4Prefix, "ipv6-prefix", ipv6Prefix, "teredo", teredoMode)));
     }
 
     @Override
@@ -93,7 +93,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     private void reloadConfig() {
         this.ipv4Prefix = getConfig().getInt("ipv4");
         this.ipv6Prefix = getConfig().getInt("ipv6");
-        this.teredoEnabled = getConfig().getBoolean("teredo", true);
+        this.teredoMode = getConfig().getString("teredo", "parse");
         this.banDuration = getConfig().getLong("ban-duration", 0);
         getCache().invalidateAll();
     }
@@ -108,10 +108,14 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
         }
         IPAddress peerAddress = peer.getPeerAddress().getAddress().withoutPrefixLength();
         if (isTeredo(peerAddress)) {
-            if (!teredoEnabled) {
-                return pass();
+            switch (teredoMode) {
+                case "skip" -> {
+                    return pass();
+                }
+                case "parse" -> peerAddress = extractTeredoIPv4(peerAddress);
+                default -> {
+                }
             }
-            peerAddress = extractTeredoIPv4(peerAddress);
         } else if (peerAddress.isIPv4Convertible()) {
             peerAddress = peerAddress.toIPv4();
         }
@@ -127,14 +131,20 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             }
             IPAddress effectiveBannedAddr = bannedAddr;
             if (isTeredo(bannedAddr)) {
-                if (!teredoEnabled) {
-                    return;
+                switch (teredoMode) {
+                    case "skip" -> {
+                        return;
+                    }
+                    case "parse" -> {
+                        Integer prefixLen = bannedAddr.getPrefixLength();
+                        if (bannedAddr.isMultiple() || (prefixLen != null && prefixLen < 128)) {
+                            return;
+                        }
+                        effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
+                    }
+                    default -> {
+                    }
                 }
-                Integer prefixLen = bannedAddr.getPrefixLength();
-                if (bannedAddr.isMultiple() || (prefixLen != null && prefixLen < 128)) {
-                    return;
-                }
-                effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
             }
             if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
                 return;

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -125,7 +125,11 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             }
             IPAddress effectiveBannedAddr = bannedAddr;
             if (isTeredo(bannedAddr)) {
-                effectiveBannedAddr = extractTeredoIPv4(bannedAddr);
+                Integer prefixLen = bannedAddr.getPrefixLength();
+                if (prefixLen != null && prefixLen < 128) {
+                    return;
+                }
+                effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
             }
             if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
                 return;

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -20,7 +20,7 @@ import com.ghostchu.peerbanhelper.wrapper.StructuredData;
 import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
 import inet.ipaddr.IPAddress;
-import inet.ipaddr.IPAddressString;
+import inet.ipaddr.ipv4.IPv4Address;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -34,7 +34,6 @@ import java.util.concurrent.atomic.AtomicReference;
 @Slf4j
 @Component
 public final class AutoRangeBan extends AbstractRuleFeatureModule implements Reloadable {
-    private static final IPAddress TEREDO_PREFIX = new IPAddressString("2001::/32").getAddress();
     @Autowired
     private PeerBanHelper peerBanHelper;
     private int ipv4Prefix;
@@ -112,7 +111,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             if (!teredoEnabled) {
                 return pass();
             }
-            peerAddress = peerAddress.toIPv4();
+            peerAddress = extractTeredoIPv4(peerAddress);
         } else if (peerAddress.isIPv4Convertible()) {
             peerAddress = peerAddress.toIPv4();
         }
@@ -135,7 +134,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
                 if (prefixLen != null && prefixLen < 128) {
                     return;
                 }
-                effectiveBannedAddr = bannedAddr.withoutPrefixLength().toIPv4();
+                effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
             }
             if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
                 return;
@@ -161,7 +160,16 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     }
 
     private static boolean isTeredo(IPAddress address) {
-        return address.isIPv6() && TEREDO_PREFIX.contains(address);
+        return address.isIPv6() && address.toIPv6().isTeredo();
+    }
+
+    private static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
+        byte[] bytes = teredoAddress.getBytes();
+        byte[] ipv4Bytes = new byte[4];
+        for (int i = 0; i < 4; i++) {
+            ipv4Bytes[i] = (byte) (~bytes[12 + i]);
+        }
+        return new IPv4Address(ipv4Bytes);
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -21,7 +21,6 @@ import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
-import inet.ipaddr.ipv4.IPv4Address;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -40,6 +39,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     private PeerBanHelper peerBanHelper;
     private int ipv4Prefix;
     private int ipv6Prefix;
+    private boolean teredoEnabled;
     @Autowired
     private JavalinWebContainer webContainer;
     private long banDuration;
@@ -83,7 +83,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     }
 
     private void handleWebAPI(Context ctx) {
-        ctx.json(new StdResp(true, null, Map.of("ipv4-prefix", ipv4Prefix, "ipv6-prefix", ipv6Prefix)));
+        ctx.json(new StdResp(true, null, Map.of("ipv4-prefix", ipv4Prefix, "ipv6-prefix", ipv6Prefix, "teredo", teredoEnabled)));
     }
 
     @Override
@@ -94,6 +94,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
     private void reloadConfig() {
         this.ipv4Prefix = getConfig().getInt("ipv4");
         this.ipv6Prefix = getConfig().getInt("ipv6");
+        this.teredoEnabled = getConfig().getBoolean("teredo", true);
         this.banDuration = getConfig().getLong("ban-duration", 0);
         getCache().invalidateAll();
     }
@@ -107,11 +108,13 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             return pass();
         }
         IPAddress peerAddress = peer.getPeerAddress().getAddress().withoutPrefixLength();
-        if (peerAddress.isIPv4Convertible()) {
-            peerAddress = peerAddress.toIPv4();
-        }
         if (isTeredo(peerAddress)) {
-            peerAddress = extractTeredoIPv4(peerAddress);
+            if (!teredoEnabled) {
+                return pass();
+            }
+            peerAddress = peerAddress.toIPv4();
+        } else if (peerAddress.isIPv4Convertible()) {
+            peerAddress = peerAddress.toIPv4();
         }
         AtomicReference<CheckResult> reference = new AtomicReference<>(null);
         IPAddress finalPeerAddress = peerAddress;
@@ -125,11 +128,14 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             }
             IPAddress effectiveBannedAddr = bannedAddr;
             if (isTeredo(bannedAddr)) {
+                if (!teredoEnabled) {
+                    return;
+                }
                 Integer prefixLen = bannedAddr.getPrefixLength();
                 if (prefixLen != null && prefixLen < 128) {
                     return;
                 }
-                effectiveBannedAddr = extractTeredoIPv4(bannedAddr.withoutPrefixLength());
+                effectiveBannedAddr = bannedAddr.withoutPrefixLength().toIPv4();
             }
             if (finalPeerAddress.isIPv4() != effectiveBannedAddr.isIPv4()) {
                 return;
@@ -156,15 +162,6 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
 
     private static boolean isTeredo(IPAddress address) {
         return address.isIPv6() && TEREDO_PREFIX.contains(address);
-    }
-
-    private static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
-        byte[] bytes = teredoAddress.getBytes();
-        byte[] ipv4Bytes = new byte[4];
-        for (int i = 0; i < 4; i++) {
-            ipv4Bytes[i] = (byte) (~bytes[12 + i]);
-        }
-        return new IPv4Address(ipv4Bytes);
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/AutoRangeBan.java
@@ -13,6 +13,7 @@ import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
+import com.ghostchu.peerbanhelper.util.IPAddressUtil;
 import com.ghostchu.peerbanhelper.web.JavalinWebContainer;
 import com.ghostchu.peerbanhelper.web.Role;
 import com.ghostchu.peerbanhelper.web.wrapper.StdResp;
@@ -20,7 +21,6 @@ import com.ghostchu.peerbanhelper.wrapper.StructuredData;
 import com.ghostchu.simplereloadlib.ReloadResult;
 import com.ghostchu.simplereloadlib.Reloadable;
 import inet.ipaddr.IPAddress;
-import inet.ipaddr.ipv4.IPv4Address;
 import io.javalin.http.Context;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
@@ -107,7 +107,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             return pass();
         }
         IPAddress peerAddress = peer.getPeerAddress().getAddress().withoutPrefixLength();
-        if (isTeredo(peerAddress)) {
+        if (IPAddressUtil.isTeredo(peerAddress)) {
             peerAddress = resolveTeredo(peerAddress);
             if (peerAddress == null) {
                 return pass();
@@ -127,7 +127,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
                 return;
             }
             IPAddress resolvedAddr = bannedAddr;
-            if (isTeredo(bannedAddr)) {
+            if (IPAddressUtil.isTeredo(bannedAddr)) {
                 resolvedAddr = resolveTeredo(bannedAddr);
                 if (resolvedAddr == null) {
                     return;
@@ -149,7 +149,7 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
             if (bannedCidr.contains(finalPeerAddress)) {
                 StructuredData structuredData = StructuredData.create()
                         .add("relatedBannedAddress", resolvedAddr.toCompressedString());
-                if (isTeredo(bannedAddr)) {
+                if (IPAddressUtil.isTeredo(bannedAddr)) {
                     structuredData.add("teredoMode", teredoMode)
                             .add("originalBannedAddress", bannedAddr.toCompressedString());
                 }
@@ -176,19 +176,10 @@ public final class AutoRangeBan extends AbstractRuleFeatureModule implements Rel
                 if (teredoAddress.isMultiple() || (prefixLen != null && prefixLen < 128)) {
                     yield null;
                 }
-                yield extractTeredoIPv4(teredoAddress.withoutPrefixLength());
+                yield IPAddressUtil.extractTeredoIPv4(teredoAddress.withoutPrefixLength());
             }
             default -> teredoAddress;
         };
-    }
-
-    private static boolean isTeredo(IPAddress address) {
-        return address.isIPv6() && address.toIPv6().isTeredo();
-    }
-
-    private static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
-        IPv4Address encodedIPv4 = teredoAddress.toIPv6().getEmbeddedIPv4Address();
-        return new IPv4Address(~encodedIPv4.intValue());
     }
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -52,6 +52,7 @@ public final class MultiDialingBlocker extends AbstractRuleFeatureModule impleme
     private long banDuration;
     private int tolerateNumV4;
     private int tolerateNumV6;
+    private String teredoMode;
 
     @Override
     public void onEnable() {
@@ -92,6 +93,7 @@ public final class MultiDialingBlocker extends AbstractRuleFeatureModule impleme
         config.put("cacheLifespan", cacheLifespan);
         config.put("keepHunting", keepHunting);
         config.put("keepHuntingTime", keepHuntingTime);
+        config.put("teredo", teredoMode);
         ctx.json(new StdResp(true, null, config));
     }
 
@@ -119,6 +121,7 @@ public final class MultiDialingBlocker extends AbstractRuleFeatureModule impleme
         cacheLifespan = getConfig().getInt("cache-lifespan") * 1000L;
         keepHunting = getConfig().getBoolean("keep-hunting");
         keepHuntingTime = getConfig().getInt("keep-hunting-time") * 1000L;
+        teredoMode = getConfig().getString("teredo", "parse");
 
         cache = CacheBuilder.newBuilder().
                 expireAfterWrite(Duration.ofMillis(cacheLifespan)).
@@ -150,7 +153,10 @@ public final class MultiDialingBlocker extends AbstractRuleFeatureModule impleme
         String torrentId = torrent.getId();
         IPAddress peerAddress = peer.getPeerAddress().getAddress();
         if (IPAddressUtil.isTeredo(peerAddress)) {
-            peerAddress = IPAddressUtil.extractTeredoIPv4(peerAddress);
+            peerAddress = IPAddressUtil.resolveTeredo(peerAddress, teredoMode);
+            if (peerAddress == null) {
+                return pass();
+            }
         }
         String peerIpStr = peerAddress.toString();
         IPAddress peerSubnet = peerAddress.isIPv4() ? peerAddress.toPrefixBlock(subnetMaskLength) : peerAddress.toPrefixBlock(subnetMaskV6Length);

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/MultiDialingBlocker.java
@@ -10,6 +10,7 @@ import com.ghostchu.peerbanhelper.module.CheckResult;
 import com.ghostchu.peerbanhelper.module.PeerAction;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
+import com.ghostchu.peerbanhelper.util.IPAddressUtil;
 import com.ghostchu.peerbanhelper.web.JavalinWebContainer;
 import com.ghostchu.peerbanhelper.web.Role;
 import com.ghostchu.peerbanhelper.web.wrapper.StdResp;
@@ -148,6 +149,9 @@ public final class MultiDialingBlocker extends AbstractRuleFeatureModule impleme
         String torrentName = torrent.getName();
         String torrentId = torrent.getId();
         IPAddress peerAddress = peer.getPeerAddress().getAddress();
+        if (IPAddressUtil.isTeredo(peerAddress)) {
+            peerAddress = IPAddressUtil.extractTeredoIPv4(peerAddress);
+        }
         String peerIpStr = peerAddress.toString();
         IPAddress peerSubnet = peerAddress.isIPv4() ? peerAddress.toPrefixBlock(subnetMaskLength) : peerAddress.toPrefixBlock(subnetMaskV6Length);
         try {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -212,6 +212,9 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
         // 处理 IPV6
         IPAddress peerPrefix;
         IPAddress peerIp = peer.getPeerAddress().getAddress();
+        if (IPAddressUtil.isTeredo(peerIp)) {
+            peerIp = IPAddressUtil.extractTeredoIPv4(peerIp);
+        }
         if (peerIp.isIPv4()) {
             peerPrefix = peerIp.toPrefixBlock(ipv4PrefixLength);
         } else {

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/rule/ProgressCheatBlocker.java
@@ -78,6 +78,7 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
     private double rewindMaximumDifference;
     private int ipv4PrefixLength;
     private int ipv6PrefixLength;
+    private String teredoMode;
     @Autowired
     private JavalinWebContainer webContainer;
     private long banDuration;
@@ -155,6 +156,7 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
         config.put("excessiveThreshold", excessiveThreshold);
         config.put("maximumDifference", maximumDifference);
         config.put("rewindMaximumDifference", rewindMaximumDifference);
+        config.put("teredo", teredoMode);
         ctx.json(new StdResp(true, null, config));
     }
 
@@ -200,6 +202,7 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
         this.maxWaitDuration = getConfig().getLong("max-wait-duration");
         this.fastPcbTestPercentage = getConfig().getDouble("fast-pcb-test-percentage");
         this.fastPcbTestBlockingDuration = getConfig().getLong("fast-pcb-test-block-duration");
+        this.teredoMode = getConfig().getString("teredo", "parse");
         getCache().invalidateAll();
     }
 
@@ -213,7 +216,10 @@ public final class ProgressCheatBlocker extends AbstractRuleFeatureModule implem
         IPAddress peerPrefix;
         IPAddress peerIp = peer.getPeerAddress().getAddress();
         if (IPAddressUtil.isTeredo(peerIp)) {
-            peerIp = IPAddressUtil.extractTeredoIPv4(peerIp);
+            peerIp = IPAddressUtil.resolveTeredo(peerIp, teredoMode);
+            if (peerIp == null) {
+                return pass();
+            }
         }
         if (peerIp.isIPv4()) {
             peerPrefix = peerIp.toPrefixBlock(ipv4PrefixLength);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -4,6 +4,7 @@ import com.ghostchu.peerbanhelper.Main;
 import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
+import inet.ipaddr.ipv4.IPv4Address;
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Contract;
@@ -142,5 +143,20 @@ public final class IPAddressUtil {
             addrs.add(address.toIPv4());
         }
         return addrs;
+    }
+
+    /**
+     * 判断地址是否为 Teredo 地址 (2001:0000::/32)
+     */
+    public static boolean isTeredo(IPAddress address) {
+        return address.isIPv6() && address.toIPv6().isTeredo();
+    }
+
+    /**
+     * 从 Teredo 地址中提取内嵌的客户端 IPv4 地址（按位取反解码）
+     */
+    public static IPAddress extractTeredoIPv4(IPAddress teredoAddress) {
+        IPv4Address encodedIPv4 = teredoAddress.toIPv6().getEmbeddedIPv4Address();
+        return new IPv4Address(~encodedIPv4.intValue());
     }
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -159,4 +159,19 @@ public final class IPAddressUtil {
         IPv4Address encodedIPv4 = teredoAddress.toIPv6().getEmbeddedIPv4Address();
         return new IPv4Address(~encodedIPv4.intValue());
     }
+
+    /**
+     * 根据模式解析 Teredo 地址，调用前应先用 isTeredo() 判断。
+     * 返回 null 表示应跳过（skip 模式）；返回原地址表示 original 模式；返回 IPv4 表示 parse 模式。
+     *
+     * @param teredoAddress Teredo 地址
+     * @param mode          处理模式：parse / skip / original
+     */
+    public static IPAddress resolveTeredo(IPAddress teredoAddress, String mode) {
+        return switch (mode) {
+            case "skip" -> null;
+            case "parse" -> extractTeredoIPv4(teredoAddress);
+            default -> teredoAddress;
+        };
+    }
 }

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -259,6 +259,11 @@ module:
     # IPV6 前缀长度
     # IPV6 prefix length
     ipv6: 48
+    # 是否解析 Teredo 地址内嵌的 IPv4 地址用于范围封禁
+    # 禁用后，Teredo 地址将被直接跳过，不参与范围封禁
+    # Whether to parse the embedded IPv4 address in Teredo addresses for range ban
+    # When disabled, Teredo addresses will be skipped entirely
+    teredo: true
   # 启用来自 BTN 网络的规则
   # Enable the network rules from BTN server, only works when you configured BTN server in config.yml
   btn:

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -259,11 +259,15 @@ module:
     # IPV6 前缀长度
     # IPV6 prefix length
     ipv6: 48
-    # 是否解析 Teredo 地址内嵌的 IPv4 地址用于范围封禁
-    # 禁用后，Teredo 地址将被直接跳过，不参与范围封禁
-    # Whether to parse the embedded IPv4 address in Teredo addresses for range ban
-    # When disabled, Teredo addresses will be skipped entirely
-    teredo: true
+    # Teredo 地址处理模式
+    # parse: 解析内嵌 IPv4 用于范围封禁（默认）
+    # skip: 跳过 Teredo 地址，不参与范围封禁
+    # original: 作为普通 IPv6 地址处理（原始行为）
+    # Teredo address handling mode
+    # parse: Parse embedded IPv4 for range ban (default)
+    # skip: Skip Teredo addresses entirely
+    # original: Treat as regular IPv6 addresses (original behavior)
+    teredo: parse
   # 启用来自 BTN 网络的规则
   # Enable the network rules from BTN server, only works when you configured BTN server in config.yml
   btn:

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -1,4 +1,4 @@
-config-version: 40
+config-version: 41
 # Check interval (Timeunit: ms)
 # 检查频率（单位：毫秒）
 check-interval: 5000

--- a/src/main/resources/profile.yml
+++ b/src/main/resources/profile.yml
@@ -142,6 +142,15 @@ module:
     # 64 = 常见的 ISP 为单个接入用户分配的前缀长度
     # 64 = The common prefix length that ISP allocate for one user
     ipv6-prefix-length: 56
+    # Teredo 地址处理模式
+    # parse: 解析内嵌 IPv4 用于前缀分组（默认）
+    # skip: 跳过 Teredo 地址，不参与检查
+    # original: 作为普通 IPv6 地址处理（原始行为）
+    # Teredo address handling mode
+    # parse: Parse embedded IPv4 for prefix grouping (default)
+    # skip: Skip Teredo addresses entirely
+    # original: Treat as regular IPv6 addresses (original behavior)
+    teredo: parse
     ban-duration: 2592000000
     # 启用持久化记录
     # Enable persist recording
@@ -313,6 +322,15 @@ module:
     # keep-hunting为true时有效，和cache-lifespan相似，对被猎杀IP的缓存持续时间
     # Only works when keep-hunting enabled, similar as cache-lifespan
     keep-hunting-time: 2592000
+    # Teredo 地址处理模式
+    # parse: 解析内嵌 IPv4 用于子网分组（默认）
+    # skip: 跳过 Teredo 地址，不参与检查
+    # original: 作为普通 IPv6 地址处理（原始行为）
+    # Teredo address handling mode
+    # parse: Parse embedded IPv4 for subnet grouping (default)
+    # skip: Skip Teredo addresses entirely
+    # original: Treat as regular IPv6 addresses (original behavior)
+    teredo: parse
   # 规则引擎，支持 AviatorScript 语言 - User script, support AviatorScript
   # 提供在 PBH 上自行编程编写规则的能力 - Provide programming ability on PBH
   expression-engine:

--- a/webui/src/api/model/profile.ts
+++ b/webui/src/api/model/profile.ts
@@ -59,6 +59,7 @@ export interface ProgressCheatBlocker {
   max_wait_duration: number
   fast_pcb_test_percentage: number
   fast_pcb_test_block_duration: number
+  teredo: string
 }
 
 export interface IpAddressBlocker {
@@ -107,6 +108,7 @@ export interface MultiDialingBlocker {
   cache_lifespan: number
   keep_hunting: boolean
   keep_hunting_time: number
+  teredo: string
 }
 
 export interface ExpressionEngine {

--- a/webui/src/api/model/profile.ts
+++ b/webui/src/api/model/profile.ts
@@ -89,7 +89,7 @@ export interface AutoRangeBan {
   ban_duration: BanDuration
   ipv4: number
   ipv6: number
-  teredo: boolean
+  teredo: string
 }
 
 export interface Btn {

--- a/webui/src/api/model/profile.ts
+++ b/webui/src/api/model/profile.ts
@@ -89,6 +89,7 @@ export interface AutoRangeBan {
   ban_duration: BanDuration
   ipv4: number
   ipv6: number
+  teredo: boolean
 }
 
 export interface Btn {

--- a/webui/src/views/settings/components/profile/components/autoRangeBan.vue
+++ b/webui/src/views/settings/components/profile/components/autoRangeBan.vue
@@ -48,9 +48,15 @@
       :tooltip="t('page.settings.tab.profile.module.autoRangeBan.teredoTips')"
     >
       <a-select v-model="model.teredo" style="width: 12em">
-        <a-option value="parse">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoParse') }}</a-option>
-        <a-option value="skip">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoSkip') }}</a-option>
-        <a-option value="original">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoOriginal') }}</a-option>
+        <a-option value="parse">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoParse')
+        }}</a-option>
+        <a-option value="skip">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoSkip')
+        }}</a-option>
+        <a-option value="original">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoOriginal')
+        }}</a-option>
       </a-select>
     </a-form-item>
   </a-space>

--- a/webui/src/views/settings/components/profile/components/autoRangeBan.vue
+++ b/webui/src/views/settings/components/profile/components/autoRangeBan.vue
@@ -42,6 +42,13 @@
         :max="128"
       ></a-input-number>
     </a-form-item>
+    <a-form-item
+      :label="t('page.settings.tab.profile.module.autoRangeBan.teredo')"
+      field="model.teredo"
+      :tooltip="t('page.settings.tab.profile.module.autoRangeBan.teredoTips')"
+    >
+      <a-switch v-model="model.teredo" />
+    </a-form-item>
   </a-space>
 </template>
 <script setup lang="ts">

--- a/webui/src/views/settings/components/profile/components/autoRangeBan.vue
+++ b/webui/src/views/settings/components/profile/components/autoRangeBan.vue
@@ -47,7 +47,11 @@
       field="model.teredo"
       :tooltip="t('page.settings.tab.profile.module.autoRangeBan.teredoTips')"
     >
-      <a-switch v-model="model.teredo" />
+      <a-select v-model="model.teredo" style="width: 12em">
+        <a-option value="parse">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoParse') }}</a-option>
+        <a-option value="skip">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoSkip') }}</a-option>
+        <a-option value="original">{{ t('page.settings.tab.profile.module.autoRangeBan.teredoOriginal') }}</a-option>
+      </a-select>
     </a-form-item>
   </a-space>
 </template>

--- a/webui/src/views/settings/components/profile/components/multiDialingBlocker.vue
+++ b/webui/src/views/settings/components/profile/components/multiDialingBlocker.vue
@@ -97,6 +97,23 @@
       </a-input-number>
       <template #extra> ={{ formatSeconds(model.keep_hunting_time) }} </template>
     </a-form-item>
+    <a-form-item
+      :label="t('page.settings.tab.profile.module.multiDialingBlocker.teredo')"
+      field="model.teredo"
+      :tooltip="t('page.settings.tab.profile.module.multiDialingBlocker.teredoTips')"
+    >
+      <a-select v-model="model.teredo" style="width: 12em">
+        <a-option value="parse">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoParse')
+        }}</a-option>
+        <a-option value="skip">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoSkip')
+        }}</a-option>
+        <a-option value="original">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoOriginal')
+        }}</a-option>
+      </a-select>
+    </a-form-item>
   </a-space>
 </template>
 <script setup lang="ts">

--- a/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
+++ b/webui/src/views/settings/components/profile/components/progressCheatBlocker.vue
@@ -153,6 +153,23 @@
         <br />{{ fastPCBTestPercentage }}%
       </a-space>
     </a-form-item>
+    <a-form-item
+      :label="t('page.settings.tab.profile.module.progressCheatBlocker.teredo')"
+      field="model.teredo"
+      :tooltip="t('page.settings.tab.profile.module.progressCheatBlocker.teredoTips')"
+    >
+      <a-select v-model="model.teredo" style="width: 12em">
+        <a-option value="parse">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoParse')
+        }}</a-option>
+        <a-option value="skip">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoSkip')
+        }}</a-option>
+        <a-option value="original">{{
+          t('page.settings.tab.profile.module.autoRangeBan.teredoOriginal')
+        }}</a-option>
+      </a-select>
+    </a-form-item>
   </a-space>
 </template>
 <script setup lang="ts">

--- a/webui/src/views/settings/components/profile/locale/en-US.ts
+++ b/webui/src/views/settings/components/profile/locale/en-US.ts
@@ -100,9 +100,12 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': 'Use global ban duration',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 prefix length',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 prefix length',
-  'page.settings.tab.profile.module.autoRangeBan.teredo': 'Parse Teredo embedded IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': 'Teredo address handling',
   'page.settings.tab.profile.module.autoRangeBan.teredoTips':
-    'When enabled, the client IPv4 address embedded in Teredo addresses will be extracted and used for range ban; when disabled, Teredo addresses will be skipped entirely',
+    'parse: Extract embedded IPv4 for range ban; skip: Skip Teredo addresses; original: Treat as regular IPv6 addresses',
+  'page.settings.tab.profile.module.autoRangeBan.teredoParse': 'Parse embedded IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoSkip': 'Skip',
+  'page.settings.tab.profile.module.autoRangeBan.teredoOriginal': 'Original (IPv6)',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     'Enable the network rules from BTN server, only works when you configured BTN server in config.yml',

--- a/webui/src/views/settings/components/profile/locale/en-US.ts
+++ b/webui/src/views/settings/components/profile/locale/en-US.ts
@@ -87,6 +87,9 @@ export default {
     'This option will allow PCB ban the Peer from downloader for disconnect it, this will heat up progress reset check quickly.',
   'page.settings.tab.profile.module.progressCheatBlocker.fastPCBTestPercentage':
     'Fast PCB test threshold',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredo': 'Teredo address handling',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredoTips':
+    'parse: Extract embedded IPv4 for prefix grouping; skip: Skip Teredo addresses; original: Treat as regular IPv6 addresses',
 
   'page.settings.tab.profile.module.ipAddressBlocker.title': 'IP address/port blacklist',
   'page.settings.tab.profile.module.ipAddressBlocker.useGlobalBanTime': 'Use global ban duration',
@@ -124,6 +127,9 @@ export default {
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting.tips':
     'If a specific IP flagged multi-dialing, ignore the caching span and keep searching other IPs in same subnet',
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting-time': 'Keep hunting time',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredo': 'Teredo address handling',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredoTips':
+    'parse: Extract embedded IPv4 for subnet grouping; skip: Skip Teredo addresses; original: Treat as regular IPv6 addresses',
 
   'page.settings.tab.profile.module.expressionEngine.title': 'AviatorScript rule engine',
   'page.settings.tab.profile.module.expressionEngine.tips':

--- a/webui/src/views/settings/components/profile/locale/en-US.ts
+++ b/webui/src/views/settings/components/profile/locale/en-US.ts
@@ -100,6 +100,9 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': 'Use global ban duration',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 prefix length',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 prefix length',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': 'Parse Teredo embedded IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoTips':
+    'When enabled, the client IPv4 address embedded in Teredo addresses will be extracted and used for range ban; when disabled, Teredo addresses will be skipped entirely',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     'Enable the network rules from BTN server, only works when you configured BTN server in config.yml',

--- a/webui/src/views/settings/components/profile/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-CN.ts
@@ -91,9 +91,12 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': '使用全局封禁时间',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 前缀长度',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 前缀长度',
-  'page.settings.tab.profile.module.autoRangeBan.teredo': '解析 Teredo 内嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': 'Teredo 地址处理',
   'page.settings.tab.profile.module.autoRangeBan.teredoTips':
-    '启用后，Teredo 地址中内嵌的客户端 IPv4 地址将被提取并用于范围封禁；禁用后，Teredo 地址将被直接跳过',
+    'parse: 解析内嵌 IPv4 用于范围封禁；skip: 跳过 Teredo 地址；original: 作为普通 IPv6 地址处理',
+  'page.settings.tab.profile.module.autoRangeBan.teredoParse': '解析内嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoSkip': '跳过',
+  'page.settings.tab.profile.module.autoRangeBan.teredoOriginal': '原始行为 (IPv6)',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     '启用来自 BTN 网络的规则，仅在 config.yml 中配置了 BTN 服务器时生效',

--- a/webui/src/views/settings/components/profile/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-CN.ts
@@ -79,6 +79,9 @@ export default {
     '此选项将允许 PCB 在 Peer 下载指定量的数据后，将其短暂的封禁一段时间以便断开其连接，这有助于快速预热进度重置检查',
   'page.settings.tab.profile.module.progressCheatBlocker.fastPCBTestPercentage':
     '快速 PCB 测试启动阈值',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredo': 'Teredo 地址处理',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredoTips':
+    'parse: 解析内嵌 IPv4 用于前缀分组；skip: 跳过 Teredo 地址；original: 作为普通 IPv6 地址处理',
 
   'page.settings.tab.profile.module.ipAddressBlocker.title': 'IP 地址封禁',
   'page.settings.tab.profile.module.ipAddressBlocker.useGlobalBanTime': '使用全局封禁时间',
@@ -114,6 +117,9 @@ export default {
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting.tips':
     '如果某IP已判定为多拨，无视缓存时间限制继续搜寻其同伙',
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting-time': '追猎时间',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredo': 'Teredo 地址处理',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredoTips':
+    'parse: 解析内嵌 IPv4 用于子网分组；skip: 跳过 Teredo 地址；original: 作为普通 IPv6 地址处理',
 
   'page.settings.tab.profile.module.expressionEngine.title': 'AviatorScript 规则引擎',
   'page.settings.tab.profile.module.expressionEngine.tips':

--- a/webui/src/views/settings/components/profile/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-CN.ts
@@ -91,6 +91,9 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': '使用全局封禁时间',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 前缀长度',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 前缀长度',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': '解析 Teredo 内嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoTips':
+    '启用后，Teredo 地址中内嵌的客户端 IPv4 地址将被提取并用于范围封禁；禁用后，Teredo 地址将被直接跳过',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     '启用来自 BTN 网络的规则，仅在 config.yml 中配置了 BTN 服务器时生效',

--- a/webui/src/views/settings/components/profile/locale/zh-TW.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-TW.ts
@@ -91,6 +91,9 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': '使用全域封禁時間',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 前綴長度',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 前綴長度',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': '解析 Teredo 內嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoTips':
+    '啟用後，Teredo 位址中內嵌的用戶端 IPv4 位址將被提取並用於範圍封禁；停用後，Teredo 位址將被直接跳過',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     '啟用來自 BTN 網路的規則，僅在 config.yml 中配置了 BTN 服務器時生效',

--- a/webui/src/views/settings/components/profile/locale/zh-TW.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-TW.ts
@@ -79,6 +79,9 @@ export default {
     '此選項將允許 PCB 在 Peer 下載指定量的資料後，將其短暫的封禁一段時間以便斷開其連接，這有助於快速預熱進度重設檢查',
   'page.settings.tab.profile.module.progressCheatBlocker.fastPCBTestPercentage':
     '快速 PCB 測試啟動閾值',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredo': 'Teredo 位址處理',
+  'page.settings.tab.profile.module.progressCheatBlocker.teredoTips':
+    'parse: 解析內嵌 IPv4 用於前綴分組；skip: 跳過 Teredo 位址；original: 作為普通 IPv6 位址處理',
 
   'page.settings.tab.profile.module.ipAddressBlocker.title': 'IP 位址封禁',
   'page.settings.tab.profile.module.ipAddressBlocker.useGlobalBanTime': '使用全域封禁時間',
@@ -114,6 +117,9 @@ export default {
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting.tips':
     '如果某IP已判定為多撥，無視快取時間限制繼續搜尋其同夥',
   'page.settings.tab.profile.module.multiDialingBlocker.keep-hunting-time': '追獵時間',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredo': 'Teredo 位址處理',
+  'page.settings.tab.profile.module.multiDialingBlocker.teredoTips':
+    'parse: 解析內嵌 IPv4 用於子網分組；skip: 跳過 Teredo 位址；original: 作為普通 IPv6 位址處理',
 
   'page.settings.tab.profile.module.expressionEngine.title': 'AviatorScript 規則引擎',
   'page.settings.tab.profile.module.expressionEngine.tips':

--- a/webui/src/views/settings/components/profile/locale/zh-TW.ts
+++ b/webui/src/views/settings/components/profile/locale/zh-TW.ts
@@ -91,9 +91,12 @@ export default {
   'page.settings.tab.profile.module.autoRangeBan.useGlobalBanTime': '使用全域封禁時間',
   'page.settings.tab.profile.module.autoRangeBan.ipv4Prefix': 'IPv4 前綴長度',
   'page.settings.tab.profile.module.autoRangeBan.ipv6Prefix': 'IPv6 前綴長度',
-  'page.settings.tab.profile.module.autoRangeBan.teredo': '解析 Teredo 內嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredo': 'Teredo 位址處理',
   'page.settings.tab.profile.module.autoRangeBan.teredoTips':
-    '啟用後，Teredo 位址中內嵌的用戶端 IPv4 位址將被提取並用於範圍封禁；停用後，Teredo 位址將被直接跳過',
+    'parse: 解析內嵌 IPv4 用於範圍封禁；skip: 跳過 Teredo 位址；original: 作為普通 IPv6 位址處理',
+  'page.settings.tab.profile.module.autoRangeBan.teredoParse': '解析內嵌 IPv4',
+  'page.settings.tab.profile.module.autoRangeBan.teredoSkip': '跳過',
+  'page.settings.tab.profile.module.autoRangeBan.teredoOriginal': '原始行為 (IPv6)',
 
   'page.settings.tab.profile.module.btn.enable.tips':
     '啟用來自 BTN 網路的規則，僅在 config.yml 中配置了 BTN 服務器時生效',


### PR DESCRIPTION
## 问题

Teredo 地址 (2001::/32) 是 IPv6 过渡隧道技术，其地址由 NAT 后的客户端动态获取，不代表真实网络拓扑。三个模块均将 Teredo 当作普通 IPv6 处理，导致误封：

- **AutoRangeBan**: 对 Teredo 地址执行 /48 范围封禁，同一 Teredo 服务器下的无关 Peer 被连锁误封
- **ProgressCheatBlocker**: Teredo Peer 被按 IPv6 前缀分组追踪进度，导致误判进度作弊
- **MultiDialingBlocker**: 同一 Teredo 服务器下的 Peer 共享 /64 前缀，被误判为多拨

## 修改内容

### 共享工具 (IPAddressUtil)
- `isTeredo()`: 判断 Teredo 地址（使用库的 `IPv6Address.isTeredo()`）
- `extractTeredoIPv4()`: 提取内嵌 IPv4（`getEmbeddedIPv4Address()` + 按位取反）
- `resolveTeredo(address, mode)`: 按模式解析（parse/skip/original）

### 三档配置模式（三个模块统一）
- **parse**（默认）: 解析内嵌 IPv4 用于范围封禁/前缀分组/子网分组
- **skip**: 跳过 Teredo 地址，不参与模块处理
- **original**: 作为普通 IPv6 地址处理（原始行为）

### 各模块适配
- **AutoRangeBan**: 解析 Teredo 内嵌 IPv4 参与 IPv4 范围封禁；非 /128 前缀块和多值地址跳过；StructuredData 增加 teredoMode 和 originalBannedAddress
- **ProgressCheatBlocker**: 解析 Teredo 内嵌 IPv4 用于前缀分组
- **MultiDialingBlocker**: 解析 Teredo 内嵌 IPv4 用于子网分组

### 配置迁移
- ProfileUpdateScript v41，config-version 40→41
- 前端三个模块均新增 Teredo 下拉选择器，三语翻译

## AI Assistance Usage Declaration

This PR is authored with assistance from AI/LLM:

- Model: qwen3.8-max-preview
- Platform: Qwen Code (https://qwen.ai)
- Agent platform: Qwen Code
- Prompt:
  - 目前，自动连锁封禁模块会误封禁 Teredo 地址 Peer，请解决这个问题
  - Teredo 地址中包含了客户端 IPv4 地址，请让自动连锁封禁模块解析并利用这些地址
  - 进度作弊检查和多拨封禁模块同样存在这一问题，建立一个新的分支处理
  - 对齐 ARB 模块现有逻辑，为用户提供原版行为选项，并尽可能复用代码封装