### PR TITLE
v9.5.1

### DIFF
--- a/.github/workflows/jvm-release.yml
+++ b/.github/workflows/jvm-release.yml
@@ -383,6 +383,8 @@ jobs:
           context: .
           file: ./Dockerfile-Release
           push: true
+          provenance: false
+          sbom: false
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 }
 
 group = "com.ghostchu.peerbanhelper"
-version = "9.5.0"
+version = "9.5.1"
 
 java {
     sourceCompatibility = JavaVersion.VERSION_25

--- a/pkg/synopkg/PeerBanHelperPackage/scripts/service-setup
+++ b/pkg/synopkg/PeerBanHelperPackage/scripts/service-setup
@@ -24,6 +24,5 @@ SHARE_PATH=$(realpath "/var/packages/${SYNOPKG_PKGNAME}/shares/peerbanhelper" 2>
 
 service_postinst ()
 {
-    echo -e "安装/升级成功！您可以从 DSM 主菜单 -> PeerBanHelper 进入 WebUI 进行后续配置。<br><span style="color:#ff0000;font-weight:bold">请注意从 8.1.0 版本开始，默认使用 host 网络模式启动。从旧版本升级的用户可能需要更新下载器的 IP 地址。</span>" | tee -a $SYNOPKG_TEMP_LOGFILE
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/Main.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/Main.java
@@ -144,6 +144,7 @@ public class Main {
                     DEF_LOCALE = defLocaleTag;
                 }
             }
+            registerStaticReloadable();
             loadPlatform();
             setupHttpServer();
             pbhServerAddress = mainConfig.getString("server.prefix", "http://127.0.0.1:" + mainConfig.getInt("server.http"));
@@ -173,6 +174,14 @@ public class Main {
             throw throwable;
         }
 
+    }
+
+    private static void registerStaticReloadable() {
+        try {
+            reloadManager.register(IPAddressUtil.class.getDeclaredMethod("reload"));
+        } catch (NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     private static void setupHttpServer() {

--- a/src/main/java/com/ghostchu/peerbanhelper/alert/AlertManagerImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/alert/AlertManagerImpl.java
@@ -108,7 +108,7 @@ public final class AlertManagerImpl implements AlertManager {
             alertEntity.setCreateAt(OffsetDateTime.now());
             alertDao.saveOrUpdate(alertEntity);
             if (push) {
-                if (!pushManager.pushMessage("[PeerBanHelper/" + level.name() + "] " + tlUI(title), tlUI(content))) {
+                if (!pushManager.pushMessage("[PeerBanHelper/" + level.name() + "] " + tlUI(title), tlUI(content), level)) {
                     log.error(tlUI(Lang.UNABLE_TO_PUSH_ALERT_VIA_PROVIDERS));
                 }
             }

--- a/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
@@ -39,7 +39,7 @@ public final class MainConfigUpdateScript {
 
     @UpdateScript(version = 48)
     public void nat64Support(YamlConfiguration bundle) {
-        conf.set("ip-remapping.nat64", false);
+        conf.set("ip-remapping.nat64", bundle.getConfigurationSection("ip-remapping.nat64"));
     }
 
     @UpdateScript(version = 47)

--- a/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/config/MainConfigUpdateScript.java
@@ -37,6 +37,11 @@ public final class MainConfigUpdateScript {
 //        }
     }
 
+    @UpdateScript(version = 48)
+    public void nat64Support(YamlConfiguration bundle) {
+        conf.set("ip-remapping.nat64", false);
+    }
+
     @UpdateScript(version = 47)
     public void teredoSupport(YamlConfiguration bundle) {
         conf.set("ip-remapping.teredo", false);

--- a/src/main/java/com/ghostchu/peerbanhelper/databasent/service/impl/common/HistoryServiceImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/databasent/service/impl/common/HistoryServiceImpl.java
@@ -10,6 +10,7 @@ import com.ghostchu.peerbanhelper.databasent.dto.UniversalFieldNumResult;
 import com.ghostchu.peerbanhelper.databasent.mapper.java.HistoryMapper;
 import com.ghostchu.peerbanhelper.databasent.service.HistoryService;
 import com.ghostchu.peerbanhelper.databasent.table.HistoryEntity;
+import com.ghostchu.peerbanhelper.util.SQLHelper;
 import com.ghostchu.peerbanhelper.util.query.Orderable;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -95,7 +96,7 @@ public class HistoryServiceImpl extends AbstractCommonService<HistoryMapper, His
             case "peer_downloaded" -> "h.peer_downloaded";
             case "peer_progress" -> "h.peer_progress";
             case "time" -> "h.ban_at";
-            default -> field; // Fallback to original, assuming it's a valid column or expression
+            default -> SQLHelper.checkSQLInjectionAndReturnSafe(field); // Fallback to original, assuming it's a valid column or expression
         };
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/databasent/service/impl/common/HistoryServiceImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/databasent/service/impl/common/HistoryServiceImpl.java
@@ -96,7 +96,7 @@ public class HistoryServiceImpl extends AbstractCommonService<HistoryMapper, His
             case "peer_downloaded" -> "h.peer_downloaded";
             case "peer_progress" -> "h.peer_progress";
             case "time" -> "h.ban_at";
-            default -> SQLHelper.checkSQLInjectionAndReturnSafe(field); // Fallback to original, assuming it's a valid column or expression
+            default -> SQLHelper.checkSafeFieldName(SQLHelper.checkSQLInjection(field)); // Fallback to original, assuming it's a valid column or expression
         };
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -45,15 +45,49 @@ public abstract class AbstractDownloader implements Downloader {
     }
 
     @NotNull
-    public PeerAddress natTranslate(PeerAddress peerAddress) {
+    public PeerAddress addressTranslate(PeerAddress peerAddress) {
+        /* Built-In NAT Translate (AutoSTUN etc.) */
+        convertIfManagedByBuiltInNat(peerAddress);
+        /* Teredo Translate */
+        convertIfTeredo(peerAddress);
+        /* NAT64 Translate */
+        convertIfNat64(peerAddress);
+        /* IPv4 Unified */
+        convertIfV4Convertable(peerAddress);
+        return peerAddress;
+    }
+
+    private PeerAddress convertIfManagedByBuiltInNat(PeerAddress peerAddress) {
         InetSocketAddress inetSocketAddress = new InetSocketAddress(peerAddress.getIp(), peerAddress.getPort());
         var translate = natAddressProvider.translate(inetSocketAddress);
         if (translate == null) return peerAddress;
-        return peerAddress.setNat(translate.getHostString(), translate.getPort());
+        peerAddress.applyNat(translate.getHostString(), translate.getPort());
+        return peerAddress;
     }
 
-    @Override
-    public PeerAddress convertIfTeredo(PeerAddress peerAddress) {
+    private PeerAddress convertIfV4Convertable(PeerAddress peerAddress) {
+        if(peerAddress.getAddress().isIPv4Convertible() && !peerAddress.getAddress().isIPv4()){
+            peerAddress.setIp(peerAddress.getAddress().toIPv4().toNormalizedString());
+            peerAddress.clearAddressCache();
+        }
+        return peerAddress;
+    }
+
+    private PeerAddress convertIfNat64(PeerAddress peerAddress) {
+        if (!Main.getMainConfig().getBoolean("ip-remapping.nat64")) {
+            return peerAddress;
+        }
+        IPAddress ipAddress = peerAddress.getAddress();
+        if (!ipAddress.isIPv6()) return peerAddress;
+        IPv6Address v6 = ipAddress.toIPv6();
+        if(!v6.isWellKnownIPv4Translatable()) return peerAddress;
+        peerAddress.applyNat(v6.getEmbeddedIPv4Address().toCompressedString(), peerAddress.getPort());
+        peerAddress.setIp(v6.getEmbeddedIPv4Address().toCompressedString());
+        peerAddress.clearAddressCache();
+        return peerAddress;
+    }
+
+    private PeerAddress convertIfTeredo(PeerAddress peerAddress) {
         if (!Main.getMainConfig().getBoolean("ip-remapping.teredo")) {
             return peerAddress;
         }
@@ -63,8 +97,8 @@ public abstract class AbstractDownloader implements Downloader {
         IPAddress clientIpv4Address = new IPv4Address(~v6.getEmbeddedIPv4Address().intValue());
         // update port to teredo port that encoded in teredo address
         int clientOutboundUdpPort = (~v6.getSegment(5).getValue().intValue()) & 0xFFFF;
-        peerAddress.setTeredo(clientIpv4Address.toNormalizedString(), clientOutboundUdpPort);
-        peerAddress.setAddress(clientIpv4Address);
+        peerAddress.applyTeredo(clientIpv4Address.toNormalizedString(), clientOutboundUdpPort);
+        peerAddress.clearAddressCache();
         return peerAddress;
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -66,7 +66,7 @@ public abstract class AbstractDownloader implements Downloader {
     }
 
     private PeerAddress convertIfV4Convertable(PeerAddress peerAddress) {
-        if(peerAddress.getAddress().isIPv4Convertible() && !peerAddress.getAddress().isIPv4()){
+        if (peerAddress.getAddress().isIPv4Convertible() && !peerAddress.getAddress().isIPv4()) {
             peerAddress.setIp(peerAddress.getAddress().toIPv4().toNormalizedString());
             peerAddress.clearAddressCache();
         }
@@ -74,15 +74,14 @@ public abstract class AbstractDownloader implements Downloader {
     }
 
     private PeerAddress convertIfNat64(PeerAddress peerAddress) {
-        if (!Main.getMainConfig().getBoolean("ip-remapping.nat64")) {
-            return peerAddress;
+        boolean originalv4 = peerAddress.getAddress().isIPv4();
+        if (originalv4) return peerAddress; // 跳过 V4 处理
+        // v6
+        var extracted = IPAddressUtil.extractIfNAT64(peerAddress.getAddress());
+        if (extracted.isIPv4()) { // v6 变 v4 了，证明 NAT64 进行了处理
+            peerAddress.applyNat(extracted.toNormalizedString(), peerAddress.getPort());
+            peerAddress.clearAddressCache();
         }
-        IPAddress ipAddress = peerAddress.getAddress();
-        if (!ipAddress.isIPv6()) return peerAddress;
-        IPv6Address v6 = ipAddress.toIPv6();
-        if(!v6.isWellKnownIPv4Translatable()) return peerAddress;
-        peerAddress.applyNat(v6.getEmbeddedIPv4Address().toCompressedString(), peerAddress.getPort());
-        peerAddress.clearAddressCache();
         return peerAddress;
     }
 

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -78,7 +78,7 @@ public abstract class AbstractDownloader implements Downloader {
         if (originalv4) return peerAddress; // 跳过 V4 处理
         // v6
         var extracted = IPAddressUtil.extractIfNAT64(peerAddress.getAddress());
-        if (extracted.isIPv4()) { // v6 变 v4 了，证明 NAT64 进行了处理
+        if (extracted != null) {
             peerAddress.applyNat(extracted.toNormalizedString(), peerAddress.getPort());
             peerAddress.clearAddressCache();
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -82,7 +82,6 @@ public abstract class AbstractDownloader implements Downloader {
         IPv6Address v6 = ipAddress.toIPv6();
         if(!v6.isWellKnownIPv4Translatable()) return peerAddress;
         peerAddress.applyNat(v6.getEmbeddedIPv4Address().toCompressedString(), peerAddress.getPort());
-        peerAddress.setIp(v6.getEmbeddedIPv4Address().toCompressedString());
         peerAddress.clearAddressCache();
         return peerAddress;
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/AbstractDownloader.java
@@ -93,11 +93,8 @@ public abstract class AbstractDownloader implements Downloader {
         }
         IPAddress ipAddress = peerAddress.getAddress();
         if (!isTeredo(peerAddress.getAddress())) return peerAddress;
-        IPv6Address v6 = ipAddress.toIPv6();
-        IPAddress clientIpv4Address = new IPv4Address(~v6.getEmbeddedIPv4Address().intValue());
-        // update port to teredo port that encoded in teredo address
-        int clientOutboundUdpPort = (~v6.getSegment(5).getValue().intValue()) & 0xFFFF;
-        peerAddress.applyTeredo(clientIpv4Address.toNormalizedString(), clientOutboundUdpPort);
+        var teredo = IPAddressUtil.extractTeredo(ipAddress);
+        peerAddress.applyTeredo(teredo.getHost(), teredo.getPort());
         peerAddress.clearAddressCache();
         return peerAddress;
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/Downloader.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/Downloader.java
@@ -45,8 +45,6 @@ public interface Downloader {
     @NotNull
     String getName();
 
-    PeerAddress convertIfTeredo(PeerAddress peerAddress);
-
     boolean isTeredo(IPAddress ipAddress);
 
     @NotNull

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/aria2next/Aria2Next.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/aria2next/Aria2Next.java
@@ -37,7 +37,6 @@ import java.net.CookieManager;
 import java.net.CookiePolicy;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 import static com.ghostchu.peerbanhelper.text.TextManager.tlUI;
 
@@ -216,7 +215,7 @@ public final class Aria2Next extends AbstractDownloader {
             // peers.forEach(p -> System.out.println(p.toString()));
             return sendRpcRequest(requestPeers, new TypeToken<List<A2Peer>>() {
             }).stream()
-                    .peek(peer-> peer.setPeerAddress(convertIfTeredo(natTranslate(peer.getPeerAddress()))))
+                    .peek(peer-> peer.setPeerAddress(addressTranslate(peer.getPeerAddress())))
                     .toList();
         } catch (DownloaderRequestException e) {
             log.error("Error on request while getting peers", e);

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/aria2next/bean/A2Task.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/aria2next/bean/A2Task.java
@@ -32,6 +32,13 @@ public class A2Task implements Torrent {
 
     @Override
     public @NotNull String getName() {
+        if (bittorrent.getInfo() == null) {
+            if (files != null && !files.isEmpty()) {
+                return files.getFirst().getPath();
+            } else {
+                return "<METADATA> " + gid;
+            }
+        }
         return bittorrent.getInfo().getName();
     }
 
@@ -42,7 +49,7 @@ public class A2Task implements Torrent {
 
     @Override
     public double getProgress() {
-        if(totalLength <= 0) return 0.0;
+        if (totalLength <= 0) return 0.0;
         return (double) completedLength / totalLength;
     }
 
@@ -77,6 +84,7 @@ public class A2Task implements Torrent {
     public static class InfoType {
         private String name;
     }
+
     @AllArgsConstructor
     @NoArgsConstructor
     @Data
@@ -87,6 +95,7 @@ public class A2Task implements Torrent {
         private String magnetLink;
         private String mode;
     }
+
     @AllArgsConstructor
     @NoArgsConstructor
     @Data

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/biglybt/BiglyBT.java
@@ -391,7 +391,7 @@ public final class BiglyBT extends AbstractDownloader {
                     peer.setIp(peer.getIp().substring(1));
                 }
                 peersList.add(new PeerImpl(
-                        convertIfTeredo(natTranslate(new PeerAddress(peer.getIp(), peer.getPort(), peer.getIp()))),
+                        addressTranslate(new PeerAddress(peer.getIp(), peer.getPort(), peer.getIp())),
                         peerId,
                         peer.getClient(),
                         peer.getStats().getRtDownloadSpeed(),

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/bitcomet/BitComet.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/bitcomet/BitComet.java
@@ -509,7 +509,7 @@ public final class BitComet extends AbstractDownloader {
                     .stream()
                     .filter(dto -> peerGroupsFilter.contains(dto.getGroup()));
             return stream.map(peer -> new PeerImpl(
-                    convertIfTeredo(natTranslate(parseAddress(peer.getIp(), peer.getRemotePort(), peer.getListenPort()))),
+                    addressTranslate(parseAddress(peer.getIp(), peer.getRemotePort(), peer.getListenPort())),
                     ByteUtil.hexToByteArray(peer.getPeerId()),
                     peer.getClientType(),
                     peer.getDlRate(),

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/deluge/Deluge.java
@@ -140,7 +140,7 @@ public final class Deluge extends AbstractDownloader {
                         peerId = peerId.substring(0, 8);
                     }
                     DelugePeer delugePeer = new DelugePeer(
-                            convertIfTeredo(natTranslate(new PeerAddress(peer.getIp(), peer.getPort(), peer.getIp()))),
+                            addressTranslate(new PeerAddress(peer.getIp(), peer.getPort(), peer.getIp())),
                             peerId,
                             peer.getClientName(),
                             peer.getTotalDownload(),

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/AbstractQbittorrent.java
@@ -632,7 +632,7 @@ public abstract class AbstractQbittorrent extends AbstractDownloader {
                         continue;
                     }
                     qbPeer.setRawIp(s);
-                    qbPeer.setPeerAddress(convertIfTeredo(natTranslate(new PeerAddress(qbPeer.getIp(), qbPeer.getPort(), qbPeer.getRawIp()))));
+                    qbPeer.setPeerAddress(addressTranslate(new PeerAddress(qbPeer.getIp(), qbPeer.getPort(), qbPeer.getRawIp())));
                     peersList.add(qbPeer);
                 }
                 return peersList;

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/enhanced/QBittorrentEE.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/qbittorrent/impl/enhanced/QBittorrentEE.java
@@ -6,7 +6,6 @@ import com.ghostchu.peerbanhelper.bittorrent.torrent.Torrent;
 import com.ghostchu.peerbanhelper.downloader.DownloaderFeatureFlag;
 import com.ghostchu.peerbanhelper.downloader.DownloaderLoginResult;
 import com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.AbstractQbittorrent;
-import com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.impl.QBittorrentPeer;
 import com.ghostchu.peerbanhelper.downloader.impl.qbittorrent.impl.QBittorrentPreferences;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.text.TranslationComponent;
@@ -131,7 +130,7 @@ public final class QBittorrentEE extends AbstractQbittorrent {
                         continue; // 当做不存在处理
                     }
                     qbPeer.setRawIp(s);
-                    qbPeer.setPeerAddress(convertIfTeredo(natTranslate(new PeerAddress(qbPeer.getIp(), qbPeer.getPort(), qbPeer.getRawIp()))));
+                    qbPeer.setPeerAddress(addressTranslate(new PeerAddress(qbPeer.getIp(), qbPeer.getPort(), qbPeer.getRawIp())));
                     peersList.add(qbPeer);
                 }
                 return peersList;

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/TRPeer.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/TRPeer.java
@@ -15,9 +15,9 @@ public final class TRPeer implements Peer {
     private final Peers backend;
     private final transient PeerAddress peerAddress;
 
-    public TRPeer(Peers backend, Function<PeerAddress, PeerAddress> natConverter,  Function<PeerAddress, PeerAddress> teredoConverter) {
+    public TRPeer(Peers backend, Function<PeerAddress, PeerAddress> addressConverter) {
         this.backend = backend;
-        this.peerAddress = teredoConverter.apply(natConverter.apply(new PeerAddress(backend.getAddress(), backend.getPort(), backend.getAddress())));
+        this.peerAddress = addressConverter.apply(new PeerAddress(backend.getAddress(), backend.getPort(), backend.getAddress()));
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/TRTorrent.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/TRTorrent.java
@@ -15,12 +15,10 @@ import java.util.stream.Collectors;
 public final class TRTorrent implements Torrent {
     private final Torrents backend;
     private final Function<PeerAddress, PeerAddress> natConverter;
-    private final Function<PeerAddress, PeerAddress> teredoConverter;
 
-    public TRTorrent(Torrents backend, Function<PeerAddress, PeerAddress> natConverter, Function<PeerAddress, PeerAddress> teredoConverter) {
+    public TRTorrent(Torrents backend, Function<PeerAddress, PeerAddress> addressConverter) {
         this.backend = backend;
-        this.natConverter = natConverter;
-        this.teredoConverter = teredoConverter;
+        this.natConverter = addressConverter;
     }
 
     @Override
@@ -70,7 +68,7 @@ public final class TRTorrent implements Torrent {
 
     @NotNull
     public List<Peer> getPeers() {
-        return backend.getPeers().stream().map(backend -> new TRPeer(backend, natConverter, teredoConverter)).collect(Collectors.toList());
+        return backend.getPeers().stream().map(backend -> new TRPeer(backend, natConverter)).collect(Collectors.toList());
     }
 
     public Integer getPeerLimit() {

--- a/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/Transmission.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/downloader/impl/transmission/Transmission.java
@@ -172,7 +172,7 @@ public final class Transmission extends AbstractDownloader {
                     return true;
                 })
                 .filter(t -> includePrivate || !t.getIsPrivate())
-                .map(backend -> new TRTorrent(backend, this::natTranslate, this::convertIfTeredo)).collect(Collectors.toList());
+                .map(backend -> new TRTorrent(backend, this::addressTranslate)).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHMetricsController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHMetricsController.java
@@ -12,6 +12,7 @@ import com.ghostchu.peerbanhelper.databasent.table.HistoryEntity;
 import com.ghostchu.peerbanhelper.metric.BasicMetrics;
 import com.ghostchu.peerbanhelper.module.AbstractFeatureModule;
 import com.ghostchu.peerbanhelper.module.impl.webapi.dto.SimpleOffsetDateTimeIntKVDTO;
+import com.ghostchu.peerbanhelper.util.SQLHelper;
 import com.ghostchu.peerbanhelper.util.TimeUtil;
 import com.ghostchu.peerbanhelper.util.WebUtil;
 import com.ghostchu.peerbanhelper.web.JavalinWebContainer;
@@ -201,7 +202,7 @@ public final class PBHMetricsController extends AbstractFeatureModule {
     private void handleHistoryNumberAccess(Context ctx) {
         // 过滤 X% 以下的数据
         String type = ctx.queryParam("type");
-        String field = ctx.queryParam("field");
+        String field = SQLHelper.checkSQLInjectionAndReturnSafe(ctx.queryParam("field"));
         double filter = Double.parseDouble(Objects.requireNonNullElse(ctx.queryParam("filter"), "0.0"));
         String downloader = ctx.queryParam("downloader");
         Integer substringLength = null;
@@ -213,9 +214,6 @@ public final class PBHMetricsController extends AbstractFeatureModule {
         }
         if (field == null) {
             throw new IllegalArgumentException("field cannot be null");
-        }
-        if (SqlInjectionUtils.check(field)) {
-            throw new IllegalArgumentException("Detected dangerous SQL injection");
         }
         List<UniversalFieldNumResult> results = switch (type) {
             case "count" -> historyService.countField(field, filter, downloader, substringLength);

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHMetricsController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHMetricsController.java
@@ -1,7 +1,6 @@
 package com.ghostchu.peerbanhelper.module.impl.webapi;
 
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
-import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.ghostchu.peerbanhelper.DownloaderServer;
 import com.ghostchu.peerbanhelper.databasent.dto.UniversalFieldDateResult;
 import com.ghostchu.peerbanhelper.databasent.dto.UniversalFieldNumResult;
@@ -202,7 +201,7 @@ public final class PBHMetricsController extends AbstractFeatureModule {
     private void handleHistoryNumberAccess(Context ctx) {
         // 过滤 X% 以下的数据
         String type = ctx.queryParam("type");
-        String field = SQLHelper.checkSQLInjectionAndReturnSafe(ctx.queryParam("field"));
+        String field = SQLHelper.checkSQLInjection(ctx.queryParam("field"));
         double filter = Double.parseDouble(Objects.requireNonNullElse(ctx.queryParam("filter"), "0.0"));
         String downloader = ctx.queryParam("downloader");
         Integer substringLength = null;

--- a/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHPushController.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/module/impl/webapi/PBHPushController.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.module.impl.webapi;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.module.AbstractFeatureModule;
 import com.ghostchu.peerbanhelper.module.impl.webapi.dto.PushWrapperDTO;
 import com.ghostchu.peerbanhelper.text.Lang;
@@ -135,7 +136,7 @@ public final class PBHPushController extends AbstractFeatureModule {
             return;
         }
         try {
-            var testResult = pushProvider.push(tl(locale(ctx), Lang.PUSH_PROVIDER_TEST_TITLE), tl(locale(ctx), Lang.PUSH_PROVIDER_TEST_DESCRIPTION, name, pushProvider.getConfigType()));
+            var testResult = pushProvider.push(tl(locale(ctx), Lang.PUSH_PROVIDER_TEST_TITLE), tl(locale(ctx), Lang.PUSH_PROVIDER_TEST_DESCRIPTION, name, pushProvider.getConfigType()), AlertLevel.INFO);
             if (testResult) {
                 ctx.json(new StdResp(true, tl(locale(ctx), Lang.PUSH_PROVIDER_API_TEST_OK), null));
             } else {

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -1,6 +1,8 @@
 package com.ghostchu.peerbanhelper.util;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.simplereloadlib.ReloadResult;
+import com.ghostchu.simplereloadlib.ReloadStatus;
 import com.google.common.net.HostAndPort;
 import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
@@ -26,6 +28,20 @@ import java.util.List;
  */
 public final class IPAddressUtil {
     private static final IPAddress INVALID_ADDRESS_MISSINGNO = new IPAddressString("127.123.123.123").getAddress();
+    private static @NotNull List<IPAddress> nat64PrefixList = List.of(new IPAddressString("64:ff9b::/96").getAddress());
+
+    public static ReloadResult reload() {
+        var prefixList64 = new ArrayList<IPAddress>();
+        for (String s : Main.getMainConfig().getStringList("ip-remapping.nat64.prefix")) {
+            try {
+                prefixList64.add(new IPAddressString(s).getAddress());
+            } catch (Exception e) {
+                log.error("Unable to parse NAT64 prefix {}", s, e);
+            }
+        }
+        nat64PrefixList = prefixList64;
+        return new ReloadResult(ReloadStatus.SUCCESS, null, null);
+    }
 
     /**
      * 将字符串转换为 IPAddress 对象，并自动进行 IPV4 in IPV6 提取转换
@@ -109,6 +125,15 @@ public final class IPAddressUtil {
         } else {
             throw new IllegalArgumentException("Invalid address length: " + localAddress.length);
         }
+    }
+
+    public static IPAddress extractIfNAT64(@NotNull IPAddress ipAddress) {
+        for (var prefix : nat64PrefixList) {
+            if (prefix.contains(ipAddress)) {
+                return ipAddress.toIPv6().getEmbeddedIPv4Address();
+            }
+        }
+        return ipAddress;
     }
 
     @NotNull

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -190,7 +190,7 @@ public final class IPAddressUtil {
             addrs.add(address.toIPv6());
         } else if (address.isIPv6() && address.isIPv4Convertible()) { // 如果是 IPV6 且可以映射 IPV4，则为其生成原始 IPV4 地址
             addrs.add(address.toIPv4());
-        } else if (address.isIPv6() && address.toIPv6().isWellKnownIPv4Translatable()  // 如果是 NAT64 地址，则为其生成原始 IPV4 地址
+        } else if (address.isIPv6() && isNAT64(address.toIPv6())  // 如果是 NAT64 地址，则为其生成原始 IPV4 地址
                 && Main.getMainConfig().getBoolean("ip-remapping.nat64", true)) {
             addrs.add(address.toIPv6().getEmbeddedIPv4Address());
         } else if (address.isIPv6() && address.toIPv6().isTeredo()) { // 如果是 Teredo，生成原始 IPV4 地址

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -1,9 +1,12 @@
 package com.ghostchu.peerbanhelper.util;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.google.common.net.HostAndPort;
 import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
+import inet.ipaddr.ipv4.IPv4Address;
+import inet.ipaddr.ipv6.IPv6Address;
 import io.sentry.Sentry;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Contract;
@@ -133,6 +136,14 @@ public final class IPAddressUtil {
         return generateRemappedPairIfPossible(banAddress);
     }
 
+    public static HostAndPort extractTeredo(IPAddress ipAddress) {
+        IPv6Address v6 = ipAddress.toIPv6();
+        IPAddress clientIpv4Address = new IPv4Address(~v6.getEmbeddedIPv4Address().intValue());
+        // update port to teredo port that encoded in teredo address
+        int clientOutboundUdpPort = (~v6.getSegment(5).getValue().intValue()) & 0xFFFF;
+        return HostAndPort.fromParts(clientIpv4Address.toNormalizedString(), clientOutboundUdpPort);
+    }
+
     private static List<IPAddress> generateRemappedPairIfPossible(IPAddress address) {
         List<IPAddress> addrs = new ArrayList<>(2);
         addrs.add(address);
@@ -140,6 +151,11 @@ public final class IPAddressUtil {
             addrs.add(address.toIPv6());
         } else if (address.isIPv6() && address.isIPv4Convertible()) { // 如果是 IPV6 且可以映射 IPV4，则为其生成原始 IPV4 地址
             addrs.add(address.toIPv4());
+        } else if (address.isIPv6() && address.toIPv6().isWellKnownIPv4Translatable()  // 如果是 NAT64 地址，则为其生成原始 IPV4 地址
+                && Main.getMainConfig().getBoolean("ip-remapping.nat64", true)) {
+            addrs.add(address.toIPv6().getEmbeddedIPv4Address());
+        } else if (address.isIPv6() && address.toIPv6().isTeredo()) { // 如果是 Teredo，生成原始 IPV4 地址
+            addrs.add(getIPAddress(extractTeredo(address).getHost()));
         }
         return addrs;
     }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -128,6 +128,7 @@ public final class IPAddressUtil {
     }
 
     public static IPAddress extractIfNAT64(@NotNull IPAddress ipAddress) {
+        if (!Main.getMainConfig().getBoolean("ip-remapping.nat64.enabled", true)) return ipAddress;
         for (var prefix : nat64PrefixList) {
             if (prefix.contains(ipAddress)) {
                 return ipAddress.toIPv6().getEmbeddedIPv4Address();

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -127,7 +127,7 @@ public final class IPAddressUtil {
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
             return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
         }
-        if (ipv6RemappingEnabled && banAddress.isIPv6() && !address.toIPv6().isWellKnownIPv4Translatable()) { // 排除 NAT64 地址
+        if (ipv6RemappingEnabled && banAddress.isIPv6() && !banAddress.toIPv6().isWellKnownIPv4Translatable()) { // 排除 NAT64 地址
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv6.remap-range");
             if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -30,6 +30,10 @@ public final class IPAddressUtil {
     private static final IPAddress INVALID_ADDRESS_MISSINGNO = new IPAddressString("127.123.123.123").getAddress();
     private static @NotNull List<IPAddress> nat64PrefixList = List.of(new IPAddressString("64:ff9b::/96").getAddress());
 
+    static {
+        reload();
+    }
+
     public static ReloadResult reload() {
         var prefixList64 = new ArrayList<IPAddress>();
         for (String s : Main.getMainConfig().getStringList("ip-remapping.nat64.prefix")) {
@@ -157,14 +161,18 @@ public final class IPAddressUtil {
         banAddress = banAddress.isIPv4Convertible() ? banAddress.toIPv4() : banAddress.toIPv6();
         boolean ipv4RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv4.enabled");
         boolean ipv6RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv6.enabled");
-        if (ipv4RemappingEnabled && banAddress.isIPv4() || isNAT64(banAddress.toIPv6())) {
+        if (ipv4RemappingEnabled && (banAddress.isIPv4() || isNAT64(banAddress.toIPv6()))) {
             if (isNAT64(banAddress.toIPv6())) {
                 banAddress = extractIfNAT64(banAddress.toIPv6());
             }
-            int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
-            if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
-                return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
-            return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
+            if (banAddress.isIPv4()) {
+                int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
+                if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
+                    return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
+                return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
+            } else {
+                log.warn("Unexpected: banAddress is not IPv4 after NAT64 extraction: {}", banAddress);
+            }
         }
         if (ipv6RemappingEnabled && banAddress.isIPv6() && !isNAT64(banAddress.toIPv6())) { // 排除 NAT64 地址
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv6.remap-range");

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -20,7 +20,9 @@ import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Slf4j
 /**
@@ -131,6 +133,7 @@ public final class IPAddressUtil {
         }
     }
 
+    @Nullable
     public static IPAddress extractIfNAT64(@NotNull IPAddress ipAddress) {
         if (!Main.getMainConfig().getBoolean("ip-remapping.nat64.enabled", true)) return ipAddress;
         for (var prefix : nat64PrefixList) {
@@ -138,7 +141,7 @@ public final class IPAddressUtil {
                 return ipAddress.toIPv6().getEmbeddedIPv4Address();
             }
         }
-        return ipAddress;
+        return null;
     }
 
     public static boolean isNAT64(@NotNull IPAddress ipAddress) {
@@ -158,29 +161,32 @@ public final class IPAddressUtil {
 
     @NotNull
     public static List<IPAddress> remapBanListAddress(@NotNull IPAddress banAddress, boolean supportRangeBan) {
+        Set<IPAddress> addresses = new HashSet<>();
         banAddress = banAddress.isIPv4Convertible() ? banAddress.toIPv4() : banAddress.toIPv6();
+        IPAddress nat64Extracted = extractIfNAT64(banAddress);
+        addresses.add(banAddress);
+        addresses.add(nat64Extracted);
         boolean ipv4RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv4.enabled");
         boolean ipv6RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv6.enabled");
-        if (ipv4RemappingEnabled && (banAddress.isIPv4() || isNAT64(banAddress.toIPv6()))) {
-            if (isNAT64(banAddress.toIPv6())) {
-                banAddress = extractIfNAT64(banAddress.toIPv6());
-            }
-            if (banAddress.isIPv4()) {
-                int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
-                if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
-                    return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
-                return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
+        if (ipv4RemappingEnabled && (banAddress.isIPv4() || nat64Extracted != null)) {
+            IPAddress addressToUse = nat64Extracted != null ? nat64Extracted : banAddress;
+            int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
+            if (addressToUse.getPrefixLength() != null && addressToUse.getPrefixLength() <= remapRange) {
+                addresses.addAll(generateRemappedPairIfPossible(addressToUse.toPrefixBlock()));
             } else {
-                log.warn("Unexpected: banAddress is not IPv4 after NAT64 extraction: {}", banAddress);
+                addresses.addAll(generateRemappedPairIfPossible(addressToUse.toPrefixBlock(remapRange)));
             }
         }
-        if (ipv6RemappingEnabled && banAddress.isIPv6() && !isNAT64(banAddress.toIPv6())) { // 排除 NAT64 地址
+        if (ipv6RemappingEnabled && banAddress.isIPv6() && nat64Extracted == null) { // 排除 NAT64 地址
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv6.remap-range");
-            if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
-                return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
-            return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
+            if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange) {
+                addresses.addAll(generateRemappedPairIfPossible(banAddress.toPrefixBlock()));
+            } else {
+                addresses.addAll(generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange)));
+            }
         }
-        return generateRemappedPairIfPossible(banAddress);
+        addresses.addAll(generateRemappedPairIfPossible(banAddress));
+        return addresses.stream().distinct().toList();
     }
 
     public static HostAndPort extractTeredo(IPAddress ipAddress) {

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -137,6 +137,16 @@ public final class IPAddressUtil {
         return ipAddress;
     }
 
+    public static boolean isNAT64(@NotNull IPAddress ipAddress) {
+        if (!Main.getMainConfig().getBoolean("ip-remapping.nat64.enabled", true)) return false;
+        for (var prefix : nat64PrefixList) {
+            if (prefix.contains(ipAddress)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     @NotNull
     public static List<IPAddress> remapBanListAddress(@NotNull IPAddress banAddress) {
         return remapBanListAddress(banAddress, true);
@@ -147,13 +157,16 @@ public final class IPAddressUtil {
         banAddress = banAddress.isIPv4Convertible() ? banAddress.toIPv4() : banAddress.toIPv6();
         boolean ipv4RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv4.enabled");
         boolean ipv6RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv6.enabled");
-        if (ipv4RemappingEnabled && banAddress.isIPv4()) {
+        if (ipv4RemappingEnabled && banAddress.isIPv4() || isNAT64(banAddress.toIPv6())) {
+            if (isNAT64(banAddress.toIPv6())) {
+                banAddress = extractIfNAT64(banAddress.toIPv6());
+            }
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
             if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
             return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
         }
-        if (ipv6RemappingEnabled && banAddress.isIPv6() && !banAddress.toIPv6().isWellKnownIPv4Translatable()) { // 排除 NAT64 地址
+        if (ipv6RemappingEnabled && banAddress.isIPv6() && !isNAT64(banAddress.toIPv6())) { // 排除 NAT64 地址
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv6.remap-range");
             if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -38,7 +38,7 @@ public final class IPAddressUtil {
         var prefixList64 = new ArrayList<IPAddress>();
         for (String s : Main.getMainConfig().getStringList("ip-remapping.nat64.prefix")) {
             try {
-                prefixList64.add(new IPAddressString(s).getAddress());
+                prefixList64.add(new IPAddressString(s).toAddress());
             } catch (Exception e) {
                 log.error("Unable to parse NAT64 prefix {}", s, e);
             }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/IPAddressUtil.java
@@ -121,13 +121,13 @@ public final class IPAddressUtil {
         banAddress = banAddress.isIPv4Convertible() ? banAddress.toIPv4() : banAddress.toIPv6();
         boolean ipv4RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv4.enabled");
         boolean ipv6RemappingEnabled = supportRangeBan && Main.getMainConfig().getBoolean("banlist-remapping.ipv6.enabled");
-        if (banAddress.isIPv4() && ipv4RemappingEnabled) {
+        if (ipv4RemappingEnabled && banAddress.isIPv4()) {
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv4.remap-range");
             if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());
             return generateRemappedPairIfPossible(banAddress.toPrefixBlock(remapRange));
         }
-        if (banAddress.isIPv6() && ipv6RemappingEnabled) {
+        if (ipv6RemappingEnabled && banAddress.isIPv6() && !address.toIPv6().isWellKnownIPv4Translatable()) { // 排除 NAT64 地址
             int remapRange = Main.getMainConfig().getInt("banlist-remapping.ipv6.remap-range");
             if (banAddress.getPrefixLength() != null && banAddress.getPrefixLength() <= remapRange)
                 return generateRemappedPairIfPossible(banAddress.toPrefixBlock());

--- a/src/main/java/com/ghostchu/peerbanhelper/util/SQLHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/SQLHelper.java
@@ -4,10 +4,26 @@ import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.regex.Pattern;
+
 @Slf4j
 public class SQLHelper {
+    private final static Pattern SAFE_FIELD_NAME = Pattern.compile("^[a-zA-Z0-9_\\-.]+$");
+
+    public static String checkSafeFieldName(@Nullable String fieldName) {
+        if(!isSafeFieldName(fieldName)) {
+            throw new IllegalArgumentException("Detected non-valid field name pattern in input: " + fieldName);
+        }
+        return fieldName;
+    }
+
+    public static boolean isSafeFieldName(@Nullable String fieldName) {
+        if (fieldName == null) return false;
+        return SAFE_FIELD_NAME.matcher(fieldName).matches();
+    }
+
     @Nullable
-    public static String checkSQLInjectionAndReturnSafe(@Nullable String sql) {
+    public static String checkSQLInjection(@Nullable String sql) {
         if (sql == null) return null;
         if (SqlInjectionUtils.check(sql)) {
             log.error("Alert: Detected user input SQL injection pattern: {}, check if your webapi exposed to public Internet.", sql);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/SQLHelper.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/SQLHelper.java
@@ -1,0 +1,18 @@
+package com.ghostchu.peerbanhelper.util;
+
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Nullable;
+
+@Slf4j
+public class SQLHelper {
+    @Nullable
+    public static String checkSQLInjectionAndReturnSafe(@Nullable String sql) {
+        if (sql == null) return null;
+        if (SqlInjectionUtils.check(sql)) {
+            log.error("Alert: Detected user input SQL injection pattern: {}, check if your webapi exposed to public Internet.", sql);
+            throw new IllegalArgumentException("Detected dangerous SQL injection pattern in input");
+        }
+        return sql;
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/PushManager.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/PushManager.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.google.gson.JsonObject;
 import org.bspfsystems.yamlconfiguration.configuration.ConfigurationSection;
 
@@ -16,7 +17,7 @@ public interface PushManager {
 
     void savePushProviders() throws IOException;
 
-    boolean pushMessage(String title, String description);
+    boolean pushMessage(String title, String description, AlertLevel level);
 
     java.util.List<PushProvider> getProviderList();
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/PushManagerImpl.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/PushManagerImpl.java
@@ -1,6 +1,7 @@
 package com.ghostchu.peerbanhelper.util.push;
 
 import com.ghostchu.peerbanhelper.Main;
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.text.Lang;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.push.impl.*;
@@ -47,6 +48,8 @@ public final class PushManagerImpl implements Reloadable, PushManager {
             case "pushdeer" -> provider = PushDeerPushProvider.loadFromYaml(name, section, httpUtil);
             case "gotify" -> provider = GotifyPushProvider.loadFromYaml(name, section, httpUtil);
             case "ntfy" -> provider = NtfyPushProvider.loadFromYaml(name, section, httpUtil);
+            case "webhook" -> provider = WebhookPushProvider.loadFromYaml(name, section, httpUtil);
+            default -> provider = null;
         }
         return provider;
     }
@@ -63,6 +66,8 @@ public final class PushManagerImpl implements Reloadable, PushManager {
             case "pushdeer" -> provider = PushDeerPushProvider.loadFromJson(name, jsonObject, httpUtil);
             case "gotify" -> provider = GotifyPushProvider.loadFromJson(name, jsonObject, httpUtil);
             case "ntfy" -> provider = NtfyPushProvider.loadFromJson(name, jsonObject, httpUtil);
+            case "webhook" -> provider = WebhookPushProvider.loadFromJson(name, jsonObject, httpUtil);
+            default -> provider = null;
         }
         return provider;
     }
@@ -104,11 +109,11 @@ public final class PushManagerImpl implements Reloadable, PushManager {
     }
 
     @Override
-    public boolean pushMessage(String title, String description) {
+    public boolean pushMessage(String title, String description, AlertLevel level) {
         AtomicBoolean anySuccess = new AtomicBoolean(false);
         providerList.forEach(pushProvider -> {
             try {
-                if (pushProvider.push(title, description)) {
+                if (pushProvider.push(title, description, level)) {
                     anySuccess.set(true);
                 }
             } catch (Exception e) {

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/PushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/PushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.google.gson.JsonObject;
 import org.bspfsystems.yamlconfiguration.configuration.ConfigurationSection;
 
@@ -11,7 +12,7 @@ public interface PushProvider {
     JsonObject saveJson();
 
     ConfigurationSection saveYaml();
-
-    boolean push(String title, String content);
+    
+    boolean push(String title, String content, AlertLevel level);
 
 }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/BarkPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/BarkPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
@@ -67,7 +68,7 @@ public final class BarkPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         Map<String, Object> map = new HashMap<>();
         map.put("title", title);
         map.put("body", content);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/GotifyPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/GotifyPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
@@ -64,7 +65,7 @@ public final class GotifyPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         Map<String, Object> map = new HashMap<>();
         map.put("title", title);
         map.put("message", content);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/NtfyPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/NtfyPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
@@ -22,6 +23,7 @@ public final class NtfyPushProvider extends AbstractPushProvider {
     private final Config config;
     private final String name;
     private final HTTPUtil httpUtil;
+    private static final String ICON_URL ="https://raw.githubusercontent.com/PBH-BTN/PeerBanHelper/refs/heads/master/src/main/resources/assets/icon.png";
 
     public NtfyPushProvider(String name, Config config, HTTPUtil httpUtil) {
         this.name = name;
@@ -71,7 +73,7 @@ public final class NtfyPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
 
         RequestBody requestBody = RequestBody.create(
                 content,
@@ -85,7 +87,7 @@ public final class NtfyPushProvider extends AbstractPushProvider {
                 .post(requestBody)
                 .header("Title", encodedTitle)
                 .header("Priority", String.valueOf(config.getPriority()))
-                .header("Icon", "https://raw.githubusercontent.com/PBH-BTN/PeerBanHelper/refs/heads/master/src/main/resources/assets/icon.png");
+                .header("Icon", ICON_URL);
 
         if (config.getToken() != null && !config.getToken().isBlank()) {
             builder.header("Authorization", "Bearer " + config.getToken());
@@ -103,6 +105,16 @@ public final class NtfyPushProvider extends AbstractPushProvider {
             throw new IllegalStateException("Failed to send push message to Ntfy", e);
         }
         return true;
+    }
+
+    private int mapLevelToPriority(AlertLevel level) {
+        return switch (level) {
+            case TIP -> 1;
+            case INFO -> 2;
+            case WARN -> 3;
+            case ERROR -> 4;
+            case FATAL -> 5;
+        };
     }
 
     @AllArgsConstructor

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/PushDeerPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/PushDeerPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
@@ -65,7 +66,7 @@ public final class PushDeerPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         Map<String, Object> map = new HashMap<>();
         map.put("pushkey", config.getPushKey());
         map.put("text", title);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/PushPlusPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/PushPlusPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
@@ -76,7 +77,7 @@ public final class PushPlusPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         Map<String, Object> args = new HashMap<>() {{
             put("token", config.getToken());
             if (config.getTopic() != null) {

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/ServerChanPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/ServerChanPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
@@ -74,7 +75,7 @@ public final class ServerChanPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         Map<String, Object> map = new HashMap<>();
         map.put("title", title);
         map.put("desp", content);

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/SmtpPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/SmtpPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
 import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
 import com.google.gson.JsonObject;
@@ -142,7 +143,7 @@ public final class SmtpPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         try {
             sendMail(config.getReceivers(), title, content);
             return true;

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/TelegramPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/TelegramPushProvider.java
@@ -1,5 +1,6 @@
 package com.ghostchu.peerbanhelper.util.push.impl;
 
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.ghostchu.peerbanhelper.util.HTTPUtil;
 import com.ghostchu.peerbanhelper.util.json.JsonUtil;
@@ -66,7 +67,7 @@ public final class TelegramPushProvider extends AbstractPushProvider {
     }
 
     @Override
-    public boolean push(String title, String content) {
+    public boolean push(String title, String content, AlertLevel level) {
         String markdown = "*" + title + "*\n" + content;
         Map<String, Object> map = new HashMap<>();
         map.put("chat_id", config.getChatId());

--- a/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/WebhookPushProvider.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/push/impl/WebhookPushProvider.java
@@ -1,0 +1,281 @@
+package com.ghostchu.peerbanhelper.util.push.impl;
+
+import com.ghostchu.peerbanhelper.alert.AlertLevel;
+import com.ghostchu.peerbanhelper.util.HTTPUtil;
+import com.ghostchu.peerbanhelper.util.TimeUtil;
+import com.ghostchu.peerbanhelper.util.json.JsonUtil;
+import com.ghostchu.peerbanhelper.util.push.AbstractPushProvider;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import okhttp3.MediaType;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.bspfsystems.yamlconfiguration.configuration.ConfigurationSection;
+import org.bspfsystems.yamlconfiguration.file.YamlConfiguration;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public final class WebhookPushProvider extends AbstractPushProvider {
+    private static final String DEFAULT_METHOD = "POST";
+    private static final String DEFAULT_CONTENT_TYPE = "application/json";
+    private static final String DEFAULT_BODY_TEMPLATE = """
+    {
+        "title":"{title}",
+        "content":"{content}",
+        "level":"{level}",
+        "date":"{date}",
+        "time":"{time}",
+        "datetime":"{datetime}",
+        "channelName":"{channelName}"
+    }
+    """;
+    private final Config config;
+    private final String name;
+    private final HTTPUtil httpUtil;
+
+    public WebhookPushProvider(String name, Config config, HTTPUtil httpUtil) {
+        this.name = name;
+        this.config = config;
+        this.httpUtil = httpUtil;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getConfigType() {
+        return "webhook";
+    }
+
+    @Override
+    public JsonObject saveJson() {
+        return JsonUtil.readObject(JsonUtil.standard().toJson(config));
+    }
+
+    @Override
+    public ConfigurationSection saveYaml() {
+        YamlConfiguration section = new YamlConfiguration();
+        section.set("type", "webhook");
+        section.set("url", config.getUrl());
+        section.set("method", config.getMethod());
+        section.set("content-type", config.getContentType());
+        section.set("body-template", config.getBodyTemplate());
+        section.set("headers", config.getHeaders());
+        return section;
+    }
+
+    public static WebhookPushProvider loadFromJson(String name, JsonObject json, HTTPUtil httpUtil) {
+        Config config = JsonUtil.getGson().fromJson(json, Config.class);
+        if (config.getMethod() == null || config.getMethod().isBlank()) {
+            config.setMethod(DEFAULT_METHOD);
+        }
+        if (config.getContentType() == null || config.getContentType().isBlank()) {
+            config.setContentType(DEFAULT_CONTENT_TYPE);
+        }
+        if (config.getBodyTemplate() == null || config.getBodyTemplate().isBlank()) {
+            config.setBodyTemplate(DEFAULT_BODY_TEMPLATE);
+        }
+        if (config.getHeaders() == null) {
+            config.setHeaders(Collections.emptyMap());
+        }
+        return new WebhookPushProvider(name, config, httpUtil);
+    }
+
+    public static WebhookPushProvider loadFromYaml(String name, ConfigurationSection section, HTTPUtil httpUtil) {
+        var url = section.getString("url", "");
+        var method = section.getString("method", DEFAULT_METHOD);
+        var contentType = section.getString("content-type", DEFAULT_CONTENT_TYPE);
+        var bodyTemplate = section.getString(
+                "body-template",
+                DEFAULT_BODY_TEMPLATE
+        );
+        Map<String, String> headers = new HashMap<>();
+        var headersSection = section.getConfigurationSection("headers");
+        if (headersSection != null) {
+            for (String key : headersSection.getKeys(false)) {
+                headers.put(key, headersSection.getString(key, ""));
+            }
+        }
+        Config config = new Config(url, method, contentType, bodyTemplate, headers);
+        return new WebhookPushProvider(name, config, httpUtil);
+    }
+
+    @Override
+    public boolean push(String title, String content, AlertLevel level) {
+        if (config.getUrl() == null || config.getUrl().isBlank()) {
+            throw new IllegalArgumentException("Webhook URL cannot be empty");
+        }
+
+        String method = normalizeMethod(config.getMethod());
+        String contentType = normalizeContentType(config.getContentType());
+        String bodyTemplate = config.getBodyTemplate() == null ? "" : config.getBodyTemplate();
+        String renderedBody = renderTemplate(bodyTemplate, title, content, contentType, false, level);
+        RequestBody requestBody = createRequestBody(method, contentType, renderedBody);
+
+        String renderedUrl = renderTemplate(config.getUrl(), title, content, contentType, true, level);
+        Request.Builder requestBuilder = new Request.Builder().url(renderedUrl).method(method, requestBody);  
+
+        applyContentType(requestBuilder, method, requestBody);
+        applyCustomHeaders(requestBuilder);
+        Request request = requestBuilder.build();
+        try (Response response = httpUtil.newBuilder().build().newCall(request).execute()) {
+            if (!response.isSuccessful()) {
+                String responseBody = response.body() != null ? response.body().string() : "<empty>";
+                throw new IllegalStateException("HTTP failed while sending push messages to Webhook: " + responseBody);
+            }
+        } catch (IllegalStateException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to send push message to Webhook", e);
+        }
+        return true;
+    }
+
+    private String normalizeMethod(String method) {
+        if (method == null || method.isBlank()) {
+            return DEFAULT_METHOD;
+        }
+        String normalized = method.toUpperCase(Locale.ROOT);
+        return switch (normalized) {
+            case "GET", "POST" -> normalized;
+            default -> throw new IllegalArgumentException("Unsupported webhook method: " + method);
+        };
+    }
+
+    private String normalizeContentType(String contentType) {
+        if (contentType == null || contentType.isBlank()) {
+            return DEFAULT_CONTENT_TYPE;
+        }
+        MediaType parsed = MediaType.parse(contentType.trim());
+        return parsed != null ? parsed.toString() : DEFAULT_CONTENT_TYPE;
+    }
+
+    private RequestBody createRequestBody(String method, String contentType, String bodyContent) {
+        if ("GET".equals(method)) {
+            return null;
+        }
+        MediaType mediaType = MediaType.parse(contentType);
+        if (mediaType == null) {
+            mediaType = MediaType.parse(DEFAULT_CONTENT_TYPE);
+        }
+        if (bodyContent.isEmpty()) {
+            if ("POST".equals(method)) {
+                return RequestBody.create("", mediaType);
+            }
+            return null;
+        }
+        return RequestBody.create(bodyContent, mediaType);
+    }
+
+    private void applyContentType(Request.Builder requestBuilder, String method, RequestBody requestBody) {
+        if (!"GET".equals(method) && requestBody != null) {
+            MediaType mediaType = requestBody.contentType();
+            if (mediaType != null) {
+                requestBuilder.header("Content-Type", mediaType.toString());
+            } else {
+                requestBuilder.header("Content-Type", DEFAULT_CONTENT_TYPE);
+            }
+        }
+    }
+
+    private void applyCustomHeaders(Request.Builder requestBuilder) {
+        if (config.getHeaders() == null) {
+            return;
+        }
+        config.getHeaders().forEach((headerKey, headerValue) -> {
+            if (headerKey != null && !headerKey.isBlank() && headerValue != null) {
+                requestBuilder.header(headerKey, encodeHeaderValue(headerValue));
+            }
+        });
+    }
+
+    /**
+     * Encodes non-ASCII characters in a header value per RFC 8187, so that the resulting value
+     * is valid for okhttp / HTTP/1.1 headers. Only encodes when the value actually contains
+     * non-ASCII bytes; pure-ASCII values pass through unchanged (and an encoded value never
+     * re-encodes, so repeated sends are safe).
+     *
+     * @see <a href="https://www.rfc-editor.org/info/rfc8187">RFC 8187</a>
+     */
+    private String encodeHeaderValue(String value) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        boolean needsEncoding = false;
+        for (int i = 0; i < value.length(); i++) {
+            if (value.charAt(i) > 0x7E) {
+                needsEncoding = true;
+                break;
+            }
+        }
+        if (!needsEncoding) {
+            return value;
+        }
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        StringBuilder sb = new StringBuilder("UTF-8''");
+        for (byte b : bytes) {
+            int c = b & 0xFF;
+            if (c > 0x7E) {
+                sb.append('%');
+                sb.append(Character.toUpperCase(Character.forDigit((c >> 4) & 0xF, 16)));
+                sb.append(Character.toUpperCase(Character.forDigit(c & 0xF, 16)));
+            } else {
+                sb.append((char) c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private String renderTemplate(String template, String title, String content, String contentType, boolean urlEncode, AlertLevel level) {
+        long currentTime = System.currentTimeMillis();
+        String date = TimeUtil.formatDateOnly(currentTime);
+        String time = TimeUtil.formatTimeOnly(currentTime);
+        String datetime = TimeUtil.formatDateTime(currentTime);
+        boolean json = contentType != null && contentType.toLowerCase(Locale.ROOT).contains("json");
+        return template
+            .replace("{title}", transformValue(title, urlEncode, json))
+            .replace("{content}", transformValue(content, urlEncode, json))
+            .replace("{level}", transformValue(level.name(), urlEncode, json))
+            .replace("{date}", transformValue(date, urlEncode, json))
+            .replace("{time}", transformValue(time, urlEncode, json))
+            .replace("{datetime}", transformValue(datetime, urlEncode, json))
+            .replace("{channelName}", transformValue(name, urlEncode, json));
+    }
+
+    private String transformValue(String value, boolean urlEncode, boolean json) {
+        if (value == null) return "";
+        if (urlEncode) {
+            return URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20");
+        }
+        if (!json) return value;
+        String s = JsonUtil.standard().toJson(value);
+        return s.substring(1, s.length() - 1);
+    }
+
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Data
+    public static class Config {
+        @SerializedName("url")
+        private String url;
+        @SerializedName("method")
+        private String method;
+        @SerializedName("content_type")
+        private String contentType;
+        @SerializedName("body_template")
+        private String bodyTemplate;
+        @SerializedName("headers")
+        private Map<String, String> headers;
+    }
+}

--- a/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
@@ -1,15 +1,18 @@
 package com.ghostchu.peerbanhelper.util.query;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import io.javalin.http.Context;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+@Slf4j
 @Getter
 public class Orderable extends LinkedHashMap<String, Boolean> {
     private final BiMap<String, String> remapping = HashBiMap.create();
@@ -66,6 +69,9 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
             return null;
         }
         for (Map.Entry<String, Boolean> entry : entrySet()) {
+            if (SqlInjectionUtils.check(entry.getKey())) {
+                throw new IllegalArgumentException("Detected dangerous SQL injection");
+            }
             queryBuilder.orderBy(true, entry.getValue(), remapping.getOrDefault(entry.getKey(), entry.getKey()));
         }
         return queryBuilder;
@@ -74,6 +80,9 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
     public String generateOrderBy() {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Boolean> entry : entrySet()) {
+            if (SqlInjectionUtils.check(entry.getKey())) {
+                throw new IllegalArgumentException("Detected dangerous SQL injection");
+            }
             if (!sb.isEmpty()) {
                 sb.append(", ");
             }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
@@ -1,7 +1,6 @@
 package com.ghostchu.peerbanhelper.util.query;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
-import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.ghostchu.peerbanhelper.util.SQLHelper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -70,7 +69,10 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
             return null;
         }
         for (Map.Entry<String, Boolean> entry : entrySet()) {
-            queryBuilder.orderBy(true, entry.getValue(), SQLHelper.checkSQLInjectionAndReturnSafe(remapping.getOrDefault(entry.getKey(), entry.getKey())));
+            queryBuilder.orderBy(true, entry.getValue(),
+                    SQLHelper.checkSafeFieldName(
+                            SQLHelper.checkSQLInjection(remapping.getOrDefault(entry.getKey(), entry.getKey())))
+            );
         }
         return queryBuilder;
     }
@@ -81,7 +83,7 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
             if (!sb.isEmpty()) {
                 sb.append(", ");
             }
-            sb.append(SQLHelper.checkSQLInjectionAndReturnSafe(remapping.getOrDefault(entry.getKey(), entry.getKey())))
+            sb.append(SQLHelper.checkSafeFieldName(SQLHelper.checkSQLInjection(remapping.getOrDefault(entry.getKey(), entry.getKey()))))
                     .append(" ")
                     .append(entry.getValue() ? "ASC" : "DESC");
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/util/query/Orderable.java
@@ -2,6 +2,7 @@ package com.ghostchu.peerbanhelper.util.query;
 
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
+import com.ghostchu.peerbanhelper.util.SQLHelper;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import io.javalin.http.Context;
@@ -69,10 +70,7 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
             return null;
         }
         for (Map.Entry<String, Boolean> entry : entrySet()) {
-            if (SqlInjectionUtils.check(entry.getKey())) {
-                throw new IllegalArgumentException("Detected dangerous SQL injection");
-            }
-            queryBuilder.orderBy(true, entry.getValue(), remapping.getOrDefault(entry.getKey(), entry.getKey()));
+            queryBuilder.orderBy(true, entry.getValue(), SQLHelper.checkSQLInjectionAndReturnSafe(remapping.getOrDefault(entry.getKey(), entry.getKey())));
         }
         return queryBuilder;
     }
@@ -80,13 +78,10 @@ public class Orderable extends LinkedHashMap<String, Boolean> {
     public String generateOrderBy() {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Boolean> entry : entrySet()) {
-            if (SqlInjectionUtils.check(entry.getKey())) {
-                throw new IllegalArgumentException("Detected dangerous SQL injection");
-            }
             if (!sb.isEmpty()) {
                 sb.append(", ");
             }
-            sb.append(remapping.getOrDefault(entry.getKey(), entry.getKey()))
+            sb.append(SQLHelper.checkSQLInjectionAndReturnSafe(remapping.getOrDefault(entry.getKey(), entry.getKey())))
                     .append(" ")
                     .append(entry.getValue() ? "ASC" : "DESC");
         }

--- a/src/main/java/com/ghostchu/peerbanhelper/wrapper/PeerAddress.java
+++ b/src/main/java/com/ghostchu/peerbanhelper/wrapper/PeerAddress.java
@@ -1,7 +1,6 @@
 package com.ghostchu.peerbanhelper.wrapper;
 
 import com.ghostchu.peerbanhelper.util.IPAddressUtil;
-import com.google.common.net.HostAndPort;
 import inet.ipaddr.IPAddress;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -29,6 +28,7 @@ public final class PeerAddress implements Comparable<PeerAddress>, Serializable 
 
 
     private String ip;
+
     private transient IPAddress address;
     /**
      * 端口可能为 0 （代表未设置）
@@ -52,7 +52,7 @@ public final class PeerAddress implements Comparable<PeerAddress>, Serializable 
         return address;
     }
 
-    public PeerAddress setNat(String nattedIp, int nattedPort) {
+    public PeerAddress applyNat(String nattedIp, int nattedPort) {
         this.ip = nattedIp;
         this.port = nattedPort;
         this.nattedClientIp = nattedIp;
@@ -62,7 +62,7 @@ public final class PeerAddress implements Comparable<PeerAddress>, Serializable 
         return this;
     }
 
-    public PeerAddress setTeredo(String teredoIp, int teredoPort) {
+    public PeerAddress applyTeredo(String teredoIp, int teredoPort) {
         this.ip = teredoIp;
         this.port = teredoPort;
         this.teredoClientIp = teredoIp;
@@ -93,5 +93,14 @@ public final class PeerAddress implements Comparable<PeerAddress>, Serializable 
         cmp = ip.compareTo(o.ip);
         if (cmp != 0) return cmp;
         return Integer.compare(port, o.port);
+    }
+
+    @Deprecated(forRemoval = true)
+    public void setAddress(IPAddress address) {
+        throw new IllegalStateException("This field is cached, use clearAddressCache() to clear the cache instead.");
+    }
+
+    public void clearAddressCache() {
+        this.address = null;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,4 +1,4 @@
-config-version: 47
+config-version: 48
 # 设置程序语言
 # Set the program language
 # default 跟随操作系统 (Follow the operating system)
@@ -211,3 +211,6 @@ ip-remapping:
   # 转换 Teredo 地址为原始 IPv4 地址处理，不影响下载器基于原始 Teredo 地址的封禁行为
   # Convert Teredo address to original IPv4 address for processing, does not affect the downloader's ban behavior based on the original Teredo address
   teredo: false
+  # 转换 NAT64 地址为原始 IPv4 地址处理
+  # Convert NAT64 address to original IPv4 address for processing
+  nat64: true

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -215,5 +215,7 @@ ip-remapping:
   # Convert NAT64 address to original IPv4 address for processing
   nat64:
     enabled: true
+    # NAT64 识别网络，处于以下网络中的地址将被视为 NAT64 地址，并将被转换为原始 IPv4 地址。若配置错误，将导致 IP 识别混乱，出现未定义行为
+    # NAT64 identification network, addresses in the following networks will be treated as NAT64 addresses and converted to original IPv4 addresses. If configured incorrectly, it will cause IP recognition confusion and undefined behavior.
     prefix:
       - "64:ff9b::/96" # Well-known prefix

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -213,4 +213,7 @@ ip-remapping:
   teredo: false
   # 转换 NAT64 地址为原始 IPv4 地址处理
   # Convert NAT64 address to original IPv4 address for processing
-  nat64: true
+  nat64:
+    enabled: true
+    prefix:
+      - "64:ff9b::/96" # Well-known prefix

--- a/webui/src/api/model/push.ts
+++ b/webui/src/api/model/push.ts
@@ -6,7 +6,8 @@ export enum PushType {
   Bark = 'bark',
   PushDeer = 'pushdeer',
   Gotify = 'gotify',
-  Ntfy = 'ntfy'
+  Ntfy = 'ntfy',
+  Webhook = 'webhook'
 }
 
 export enum SMTPEncryption {
@@ -14,6 +15,16 @@ export enum SMTPEncryption {
   StartTLS = 'STARTTLS',
   EnforceStartTLS = 'ENFORCE_STARTTLS',
   SSLTLS = 'SSLTLS'
+}
+
+export enum WebhookMethod {
+  GET = 'GET',
+  POST = 'POST'
+}
+
+export enum WebhookContentType {
+  JSON = 'application/json',
+  PlainText = 'text/plain'
 }
 
 interface SMTPConfigBase {
@@ -79,6 +90,14 @@ export interface NtfyConfig {
   tags?: string
 }
 
+export interface WebhookConfig {
+  url: string
+  method: WebhookMethod
+  content_type: WebhookContentType
+  body_template: string
+  headers: Record<string, string>
+}
+
 export type PushConfig = {
   name: string
 } & (
@@ -90,4 +109,5 @@ export type PushConfig = {
   | { type: PushType.PushDeer; config: PushDeerConfig }
   | { type: PushType.Gotify; config: GotifyConfig }
   | { type: PushType.Ntfy; config: NtfyConfig }
+  | { type: PushType.Webhook; config: WebhookConfig }
 )

--- a/webui/src/views/settings/components/config/components/push/editPush.vue
+++ b/webui/src/views/settings/components/config/components/push/editPush.vue
@@ -67,10 +67,13 @@
             <a-radio :value="PushType.Ntfy">{{
               t('page.settings.tab.config.push.form.type.' + PushType.Ntfy)
             }}</a-radio>
+            <a-radio :value="PushType.Webhook">{{
+              t('page.settings.tab.config.push.form.type.' + PushType.Webhook)
+            }}</a-radio>
           </a-grid>
         </a-radio-group>
       </a-form-item>
-      <component :is="formMap[form.type]" v-model="form.config" />
+      <component :is="formMap[form.type]" ref="activeFormRef" v-model="form.config" />
     </a-form>
   </a-modal>
 </template>
@@ -128,6 +131,9 @@ const formMap: Record<PushType, Component> = {
   ),
   [PushType.Ntfy]: defineAsyncComponent(
     () => import('@/views/settings/components/config/components/push/forms/ntfyForm.vue')
+  ),
+  [PushType.Webhook]: defineAsyncComponent(
+    () => import('@/views/settings/components/config/components/push/forms/webhookForm.vue')
   )
 }
 
@@ -136,9 +142,13 @@ const emits = defineEmits<{
 }>()
 
 const formRef = ref<InstanceType<typeof Form>>()
+const activeFormRef = ref<{ validate?: () => boolean }>()
 const handleBeforeOk = async () => {
   const validateError = await formRef.value?.validate()
   if (validateError) {
+    return false
+  }
+  if (activeFormRef.value?.validate?.() === false) {
     return false
   }
   try {
@@ -189,6 +199,9 @@ const handleOk = async () => {
 const handleTest = async () => {
   const validateError = await formRef.value?.validate()
   if (validateError) {
+    return
+  }
+  if (activeFormRef.value?.validate?.() === false) {
     return
   }
   testLoading.value = true

--- a/webui/src/views/settings/components/config/components/push/forms/webhookForm.vue
+++ b/webui/src/views/settings/components/config/components/push/forms/webhookForm.vue
@@ -1,0 +1,385 @@
+<template>
+  <a-form-item
+    field="config.url"
+    :label="t('page.settings.tab.config.push.form.webhook.url')"
+    required
+    validate-trigger="blur"
+    :rules="urlRules"
+  >
+    <a-input
+      v-model="model.url"
+      :placeholder="t('page.settings.tab.config.push.form.webhook.url.placeholder')"
+      allow-clear
+    />
+  </a-form-item>
+
+  <a-form-item
+    field="config.method"
+    :label="t('page.settings.tab.config.push.form.webhook.method')"
+    required
+  >
+    <a-select v-model="model.method" style="width: 7em" :options="Object.values(WebhookMethod)" />
+  </a-form-item>
+
+  <a-form-item
+    v-if="!isGetMethod"
+    field="config.content_type"
+    :label="t('page.settings.tab.config.push.form.webhook.content_type')"
+    required
+  >
+    <a-select
+      v-model="model.content_type"
+      style="width: 12em"
+      :options="Object.values(WebhookContentType)"
+    />
+  </a-form-item>
+
+  <a-form-item
+    v-if="!isGetMethod"
+    field="config.body_template"
+    :label="t('page.settings.tab.config.push.form.webhook.body_template')"
+    required
+    :rules="bodyTemplateRules"
+  >
+    <div class="textarea-wrapper">
+      <div class="editor-container">
+        <VueMonacoEditor
+          v-model:value="model.body_template"
+          :theme="darkStore.isDark ? 'vs-dark' : 'vs'"
+          :language="contentTypeLanguage"
+          :options="editorOptions"
+          @mount="onEditorMount"
+        />
+      </div>
+      <a-tooltip position="right">
+        <template #content>
+          <div class="tooltip-content">
+            {{
+              t('page.settings.tab.config.push.form.webhook.body_template.tooltip', {
+                l: '{',
+                r: '}'
+              })
+            }}
+          </div>
+        </template>
+        <span class="textarea-tooltip-icon">
+          <icon-exclamation-circle />
+        </span>
+      </a-tooltip>
+    </div>
+  </a-form-item>
+
+  <a-form-item
+    field="config.headers"
+    :label="t('page.settings.tab.config.push.form.webhook.headers')"
+    :help="
+      hasNonAsciiHeaderValue
+        ? t('page.settings.tab.config.push.form.webhook.headers.error.nonAsciiValue')
+        : undefined
+    "
+  >
+    <a-space direction="vertical" style="width: 100%">
+      <a-button @click="addHeader">
+        <template #icon>
+          <icon-plus />
+        </template>
+        {{ t('page.settings.tab.config.push.form.webhook.headers.add') }}
+      </a-button>
+      <a-list
+        v-if="headerRows.length > 0"
+        class="header-list"
+        :pagination-props="controlledPaginationProps"
+        :data="dataWithIndex"
+      >
+        <template #item="{ item }">
+          <a-list-item>
+            <div class="header-row">
+              <div class="header-field">
+                <a-input
+                  v-model="headerRows[item.index]!.key"
+                  class="header-input"
+                  :placeholder="t('page.settings.tab.config.push.form.webhook.headers.key')"
+                  :error="
+                    headerTouched[item.index]?.key && Boolean(headerRowErrors[item.index]?.key)
+                  "
+                  allow-clear
+                  @blur="markHeaderTouched(item.index, 'key')"
+                />
+                <transition name="form-blink" appear>
+                  <div
+                    v-if="headerTouched[item.index]?.key && headerRowErrors[item.index]?.key"
+                    class="header-row-error"
+                  >
+                    {{ headerRowErrors[item.index]!.key }}
+                  </div>
+                </transition>
+              </div>
+              <a-input
+                v-model="headerRows[item.index]!.value"
+                class="header-input"
+                :placeholder="t('page.settings.tab.config.push.form.webhook.headers.value')"
+                allow-clear
+                @blur="markHeaderTouched(item.index, 'value')"
+              />
+            </div>
+            <template #actions>
+              <a-button
+                status="danger"
+                shape="circle"
+                type="text"
+                @click="removeHeader(item.index)"
+              >
+                <template #icon>
+                  <icon-delete />
+                </template>
+              </a-button>
+            </template>
+          </a-list-item>
+        </template>
+      </a-list>
+    </a-space>
+  </a-form-item>
+</template>
+
+<script setup lang="ts">
+import { WebhookContentType, WebhookMethod, type WebhookConfig } from '@/api/model/push'
+import { formInjectionKey, type FormContext } from '@arco-design/web-vue/es/form/context'
+import type { FieldRule } from '@arco-design/web-vue'
+import { VueMonacoEditor, loader } from '@guolao/vue-monaco-editor'
+import * as monaco from 'monaco-editor'
+import { useDarkStore } from '@/stores/dark'
+import { computed, inject, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+loader.config({ monaco })
+
+const { t } = useI18n()
+const model = defineModel<WebhookConfig>({ required: true })
+const formCtx = inject<FormContext>(formInjectionKey)
+
+if (model.value.url === undefined) model.value.url = ''
+if (model.value.method === undefined) model.value.method = WebhookMethod.POST
+if (model.value.content_type === undefined) model.value.content_type = WebhookContentType.JSON
+if (model.value.body_template === undefined) {
+  model.value.body_template = `
+{
+    "title":"{title}",
+    "content":"{content}",
+    "level":"{level}",
+    "date":"{date}",
+    "time":"{time}",
+    "datetime":"{datetime}",
+    "channelName":"{channelName}"
+}
+`
+}
+if (model.value.headers === undefined) model.value.headers = {}
+
+const darkStore = useDarkStore()
+
+type HeaderRow = { key: string; value: string }
+
+const isGetMethod = computed(() => model.value.method === WebhookMethod.GET)
+
+const contentTypeLanguage = computed(() =>
+  model.value.content_type === WebhookContentType.JSON ? 'json' : 'plaintext'
+)
+
+const isValidUrl = (value: string) => {
+  return URL.canParse(value)
+}
+
+const urlRules: FieldRule<string> = {
+  type: 'string',
+  required: true,
+  validator: (value, callback) => {
+    if (!value) return callback(t('page.settings.tab.config.push.form.webhook.url.error.required'))
+    if (!value.startsWith('http://') && !value.startsWith('https://')) {
+      return callback(t('page.settings.tab.config.push.form.webhook.url.error.invalidSchema'))
+    }
+    if (!isValidUrl(value)) {
+      return callback(t('page.settings.tab.config.push.form.webhook.url.error.invalidUrl'))
+    }
+    callback()
+  }
+}
+
+const editorOptions = {
+  automaticLayout: true,
+  minimap: { enabled: false },
+  lineNumbers: 'off',
+  folding: false,
+  lineDecorationsWidth: 0,
+  lineNumbersMinChars: 0,
+  scrollBeyondLastLine: false,
+  wordWrap: 'on' as const,
+  tabSize: 2
+}
+
+const isValidJson = (value: string) => {
+  try {
+    JSON.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const bodyTemplateRules: FieldRule<string> = {
+  validator: (value, callback) => {
+    if (model.value.content_type === WebhookContentType.JSON && value && !isValidJson(value)) {
+      return callback(
+        t('page.settings.tab.config.push.form.webhook.body_template.error.invalidJson')
+      )
+    }
+    callback()
+  }
+}
+
+const onEditorMount = (editor: monaco.editor.IStandaloneCodeEditor) => {
+  editor.onDidBlurEditorWidget(() => {
+    formCtx?.validateField('config.body_template')
+  })
+}
+
+const createHeaderRows = (headers: Record<string, string> = {}) =>
+  Object.entries(headers).map(([key, value]) => ({ key, value }))
+
+const headerRows = ref<HeaderRow[]>(createHeaderRows(model.value.headers))
+const headerTouched = ref<{ key: boolean; value: boolean }[]>(
+  headerRows.value.map(() => ({ key: false, value: false }))
+)
+const currentPage = ref(1)
+const pageSize = computed(() => 5)
+
+const controlledPaginationProps = computed(() => ({
+  pageSize: pageSize.value,
+  total: headerRows.value.length,
+  current: currentPage.value,
+  onChange: (page: number) => {
+    currentPage.value = page
+  }
+}))
+
+const dataWithIndex = computed(() => {
+  return headerRows.value.map((item, index) => ({ ...item, index }))
+})
+
+const syncHeadersToModel = () => {
+  const headers: Record<string, string> = {}
+  headerRows.value.forEach((row) => {
+    const key = row.key.trim()
+    if (key) headers[key] = row.value
+  })
+  model.value.headers = headers
+}
+
+watch(headerRows, () => syncHeadersToModel(), { deep: true })
+
+watch(model, (value) => {
+  if (value.headers === undefined) value.headers = {}
+  headerRows.value = createHeaderRows(value.headers)
+  headerTouched.value = headerRows.value.map(() => ({ key: false, value: false }))
+  currentPage.value = 1
+})
+
+const addHeader = () => {
+  headerRows.value.push({ key: '', value: '' })
+  headerTouched.value.push({ key: false, value: false })
+  currentPage.value = Math.ceil(headerRows.value.length / pageSize.value)
+}
+
+const removeHeader = (index: number) => {
+  headerRows.value.splice(index, 1)
+  headerTouched.value.splice(index, 1)
+  const lastPage = Math.max(1, Math.ceil(headerRows.value.length / pageSize.value))
+  if (currentPage.value > lastPage) currentPage.value = lastPage
+}
+
+const markHeaderTouched = (index: number, field: 'key' | 'value') => {
+  const target = headerTouched.value[index]
+  if (target) target[field] = true
+}
+
+const hasNonAsciiHeaderValue = computed(() =>
+  headerRows.value.some((row) => /[^\x00-\x7F]/.test(row.value))
+)
+
+const headerRowErrors = computed(() => {
+  const names = new Set<string>()
+  return headerRows.value.map((row) => {
+    const key = row.key.trim()
+    if (!key && row.value.trim()) {
+      return { key: t('page.settings.tab.config.push.form.webhook.headers.error.emptyKey') }
+    }
+    if (!key) return { key: '' }
+    if (/[^\x21-\x7E]/.test(key)) {
+      return { key: t('page.settings.tab.config.push.form.webhook.headers.error.invalidKey') }
+    }
+    const normalizedKey = key.toLowerCase()
+    if (names.has(normalizedKey)) {
+      return { key: t('page.settings.tab.config.push.form.webhook.headers.error.duplicateKey') }
+    }
+    names.add(normalizedKey)
+    return { key: '' }
+  })
+})
+
+const validate = () => {
+  formCtx?.validateField('config.body_template')
+  headerTouched.value = headerTouched.value.map(() => ({ key: true, value: true }))
+  return !headerRowErrors.value.some((error) => error.key)
+}
+
+defineExpose({ validate })
+</script>
+
+<style scoped>
+.textarea-wrapper {
+  position: relative;
+  width: 100%;
+}
+
+.editor-container {
+  height: 240px;
+}
+
+.tooltip-content {
+  max-width: 340px;
+  white-space: pre-line;
+}
+
+.textarea-tooltip-icon {
+  position: absolute;
+  top: 8px;
+  right: 24px;
+  color: var(--color-text-3);
+  cursor: pointer;
+  z-index: 10;
+}
+
+.header-row {
+  display: flex;
+  gap: 8px;
+}
+
+.header-field {
+  flex: 1;
+  min-width: 0;
+}
+
+.header-input {
+  flex: 1;
+}
+
+.header-row-error {
+  margin-top: 4px;
+  font-size: 14px;
+  line-height: 1.5;
+  color: rgb(var(--danger-6));
+}
+
+:deep(.arco-form-item-message-help) {
+  color: rgb(var(--warning-6));
+}
+</style>

--- a/webui/src/views/settings/components/config/components/push/pushCard.vue
+++ b/webui/src/views/settings/components/config/components/push/pushCard.vue
@@ -58,7 +58,8 @@ const colorList: Record<PushType, CSSProperties['color']> = {
   [PushType.Bark]: '#a4a6ab',
   [PushType.PushDeer]: '#00d8ff',
   [PushType.Gotify]: '#007ACC',
-  [PushType.Ntfy]: '#57A773'
+  [PushType.Ntfy]: '#57A773',
+  [PushType.Webhook]: '#696969'
 }
 const avatarList: Record<PushType, string> = {
   [PushType.Email]: 'M',
@@ -68,7 +69,8 @@ const avatarList: Record<PushType, string> = {
   [PushType.Bark]: 'B',
   [PushType.PushDeer]: 'D',
   [PushType.Gotify]: 'G',
-  [PushType.Ntfy]: 'N'
+  [PushType.Ntfy]: 'N',
+  [PushType.Webhook]: 'W'
 }
 const emits = defineEmits<{
   (e: 'deleted'): void

--- a/webui/src/views/settings/components/config/locale/en-US.ts
+++ b/webui/src/views/settings/components/config/locale/en-US.ts
@@ -129,6 +129,7 @@ export default {
   'page.settings.tab.config.push.form.type.pushdeer': 'PushDeer',
   'page.settings.tab.config.push.form.type.gotify': 'Gotify',
   'page.settings.tab.config.push.form.type.ntfy': 'Ntfy',
+  'page.settings.tab.config.push.form.type.webhook': 'Webhook',
 
   'page.settings.tab.config.push.form.stmp.host': 'Host',
   'page.settings.tab.config.push.form.stmp.port': 'Port',
@@ -161,6 +162,31 @@ export default {
   'page.settings.tab.config.push.form.ntfy.token': 'Access Token',
   'page.settings.tab.config.push.form.ntfy.priority': 'Priority',
   'page.settings.tab.config.push.form.ntfy.tags': 'Tags',
+
+  'page.settings.tab.config.push.form.webhook.url': 'URL',
+  'page.settings.tab.config.push.form.webhook.url.placeholder': 'Enter webhook URL',
+  'page.settings.tab.config.push.form.webhook.url.error.required': 'Enter webhook URL',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidSchema':
+    'Webhook URL must start with http:// or https://',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidUrl': 'Invalid webhook URL',
+  'page.settings.tab.config.push.form.webhook.method': 'HTTP Method',
+  'page.settings.tab.config.push.form.webhook.content_type': 'Content Type',
+  'page.settings.tab.config.push.form.webhook.body_template': 'Message Template',
+  'page.settings.tab.config.push.form.webhook.body_template.tooltip':
+    'Supported variables: {l}title{r} {l}content{r} {l}level{r} {l}date{r} {l}time{r} {l}datetime{r} {l}channelName{r}\nNote: {l}level{r}: TIP, *INFO*, WARN, ERROR, FATAL',
+  'page.settings.tab.config.push.form.webhook.body_template.error.invalidJson':
+    'Message template is not valid JSON',
+  'page.settings.tab.config.push.form.webhook.headers': 'Custom Headers',
+  'page.settings.tab.config.push.form.webhook.headers.key': 'Header Name',
+  'page.settings.tab.config.push.form.webhook.headers.value': 'Header Value',
+  'page.settings.tab.config.push.form.webhook.headers.add': 'Add Header',
+  'page.settings.tab.config.push.form.webhook.headers.error.emptyKey': 'Header name is required',
+  'page.settings.tab.config.push.form.webhook.headers.error.duplicateKey':
+    'Header name cannot be duplicated',
+  'page.settings.tab.config.push.form.webhook.headers.error.invalidKey':
+    'Header name may only contain ASCII characters (33-126)',
+  'page.settings.tab.config.push.form.webhook.headers.error.nonAsciiValue':
+    'Header value contains non-ASCII characters. It will be encoded per RFC 8187 when sent.',
 
   'page.settings.tab.config.push.form.action.ok': 'Ok',
   'page.settings.tab.config.push.form.action.cancel': 'Cancel',

--- a/webui/src/views/settings/components/config/locale/zh-CN.ts
+++ b/webui/src/views/settings/components/config/locale/zh-CN.ts
@@ -125,6 +125,7 @@ export default {
   'page.settings.tab.config.push.form.type.pushdeer': 'PushDeer',
   'page.settings.tab.config.push.form.type.gotify': 'Gotify',
   'page.settings.tab.config.push.form.type.ntfy': 'Ntfy',
+  'page.settings.tab.config.push.form.type.webhook': 'Webhook',
 
   'page.settings.tab.config.push.form.stmp.host': '主机',
   'page.settings.tab.config.push.form.stmp.port': '端口号',
@@ -156,6 +157,30 @@ export default {
   'page.settings.tab.config.push.form.ntfy.token': '访问令牌',
   'page.settings.tab.config.push.form.ntfy.priority': '优先级',
   'page.settings.tab.config.push.form.ntfy.tags': '标签',
+
+  'page.settings.tab.config.push.form.webhook.url': 'URL',
+  'page.settings.tab.config.push.form.webhook.url.placeholder': '请输入 Webhook 地址',
+  'page.settings.tab.config.push.form.webhook.url.error.required': '请输入 Webhook 地址',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidSchema':
+    'Webhook 地址必须以 http:// 或 https:// 开头',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidUrl': 'Webhook 地址格式不正确',
+  'page.settings.tab.config.push.form.webhook.method': '请求方法',
+  'page.settings.tab.config.push.form.webhook.content_type': '内容类型',
+  'page.settings.tab.config.push.form.webhook.body_template': '消息模板',
+  'page.settings.tab.config.push.form.webhook.body_template.tooltip':
+    '支持变量：{l}title{r} {l}content{r} {l}level{r} {l}date{r} {l}time{r} {l}datetime{r} {l}channelName{r}\n额外说明：{l}level{r}: TIP, *INFO*, WARN, ERROR, FATAL',
+  'page.settings.tab.config.push.form.webhook.body_template.error.invalidJson':
+    '消息模板不是有效的 JSON',
+  'page.settings.tab.config.push.form.webhook.headers': '自定义请求头',
+  'page.settings.tab.config.push.form.webhook.headers.key': 'Header 名称',
+  'page.settings.tab.config.push.form.webhook.headers.value': 'Header 值',
+  'page.settings.tab.config.push.form.webhook.headers.add': '新增请求头',
+  'page.settings.tab.config.push.form.webhook.headers.error.emptyKey': 'Header 名称不能为空',
+  'page.settings.tab.config.push.form.webhook.headers.error.duplicateKey': 'Header 名称不能重复',
+  'page.settings.tab.config.push.form.webhook.headers.error.invalidKey':
+    'Header 名称只能包含 ASCII 可见字符（33-126）',
+  'page.settings.tab.config.push.form.webhook.headers.error.nonAsciiValue':
+    'Header 值包含非 ASCII 字符，后端将按 RFC 8187 编码后发送',
 
   'page.settings.tab.config.push.form.action.ok': '确定',
   'page.settings.tab.config.push.form.action.cancel': '取消',

--- a/webui/src/views/settings/components/config/locale/zh-TW.ts
+++ b/webui/src/views/settings/components/config/locale/zh-TW.ts
@@ -126,6 +126,7 @@ export default {
   'page.settings.tab.config.push.form.type.pushdeer': 'PushDeer',
   'page.settings.tab.config.push.form.type.gotify': 'Gotify',
   'page.settings.tab.config.push.form.type.ntfy': 'Ntfy',
+  'page.settings.tab.config.push.form.type.webhook': 'Webhook',
 
   'page.settings.tab.config.push.form.stmp.host': '主機',
   'page.settings.tab.config.push.form.stmp.port': '埠號',
@@ -157,6 +158,30 @@ export default {
   'page.settings.tab.config.push.form.ntfy.token': '訪問令牌',
   'page.settings.tab.config.push.form.ntfy.priority': '優先級',
   'page.settings.tab.config.push.form.ntfy.tags': '標籤',
+
+  'page.settings.tab.config.push.form.webhook.url': 'URL',
+  'page.settings.tab.config.push.form.webhook.url.placeholder': '請輸入 Webhook 位址',
+  'page.settings.tab.config.push.form.webhook.url.error.required': '請輸入 Webhook 位址',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidSchema':
+    'Webhook 位址必須以 http:// 或 https:// 開頭',
+  'page.settings.tab.config.push.form.webhook.url.error.invalidUrl': 'Webhook 位址格式不正確',
+  'page.settings.tab.config.push.form.webhook.method': '請求方法',
+  'page.settings.tab.config.push.form.webhook.content_type': '內容類型',
+  'page.settings.tab.config.push.form.webhook.body_template': '消息模板',
+  'page.settings.tab.config.push.form.webhook.body_template.tooltip':
+    '支援變數：{l}title{r} {l}content{r} {l}level{r} {l}date{r} {l}time{r} {l}datetime{r} {l}channelName{r}\n額外說明：{l}level{r}: TIP, *INFO*, WARN, ERROR, FATAL',
+  'page.settings.tab.config.push.form.webhook.body_template.error.invalidJson':
+    '消息模板不是有效的 JSON',
+  'page.settings.tab.config.push.form.webhook.headers': '自訂請求頭',
+  'page.settings.tab.config.push.form.webhook.headers.key': 'Header 名稱',
+  'page.settings.tab.config.push.form.webhook.headers.value': 'Header 值',
+  'page.settings.tab.config.push.form.webhook.headers.add': '新增請求頭',
+  'page.settings.tab.config.push.form.webhook.headers.error.emptyKey': 'Header 名稱不能為空',
+  'page.settings.tab.config.push.form.webhook.headers.error.duplicateKey': 'Header 名稱不能重複',
+  'page.settings.tab.config.push.form.webhook.headers.error.invalidKey':
+    'Header 名稱只能包含 ASCII 可見字元（33-126）',
+  'page.settings.tab.config.push.form.webhook.headers.error.nonAsciiValue':
+    'Header 值包含非 ASCII 字元，後端將依 RFC 8187 編碼後發送',
 
   'page.settings.tab.config.push.form.action.ok': '確定',
   'page.settings.tab.config.push.form.action.cancel': '取消',


### PR DESCRIPTION
## 修复安全漏洞

* Orderable 查询可能传入 SQL 注入语句的问题 @Ghost-chu 鸣谢：@tonghuaroot

## 新功能

* NAT64 地址支持 @Ghost-chu 
  * 目前默认支持 WKP 的 NAT64 地址。由于无法可靠探测某个网络是否为 NAT64 网络，因此如果您正在使用 NSP 的 NAT64 地址，请手动编辑配置文件。
* 新的 webhook 通知渠道 @gongfuture  

## 错误修复

* 封禁列表重映射未正确处理 Teredo 地址 @Ghost-chu 
* 修复在较新的 DSM 上，安装 PeerBanHelper 可能出现错误的问题 @Ghost-chu

## 开发者更改

* PeerAddress 现在包含新的 `teredoClientIp` 和 `teredoClientUdpPort` 字段，指示 Teredo 有关的 IP 元数据
* PeerAddress 的 `nattedIp` 和 `nattedPort` 除原 AutoSTUN 地址转换使用外，现在 NAT64 地址转换也将会更新这些字段。
* 现在规则检查模块无需为了转换 ::ffff: 地址进行刻意的 `isIPv4Convertible` 检查，PeerBanHelper 现在统一处理这些转换。这包括：Well-Knowned NAT64地址(RFC-6146, RFC-6052)、Teredo 地址(RFC-4380, RFC-5991)、IPv4-mapped IPv6 地址(RFC-4291, RFC-4038)